### PR TITLE
feat: Add globe-based itinerary builder with Resium/CesiumJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# Cesium assets (symlinked)
+/public/cesium

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,26 @@
 import type { NextConfig } from "next";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const webpack = require("webpack");
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Turbopack config (Next.js 16 default)
+  turbopack: {
+    // Empty config to silence the warning
+  },
+  // Webpack config for production builds and fallback
+  webpack: (config) => {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        CESIUM_BASE_URL: JSON.stringify("cesium"),
+      })
+    );
+    return config;
+  },
+  // Environment variables
+  env: {
+    CESIUM_BASE_URL: "cesium",
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ai-sdk/react": "^3.0.40",
         "@prisma/client": "^7.2.0",
         "ai": "^6.0.38",
+        "cesium": "^1.137.0",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.3",
         "next": "16.1.2",
@@ -19,7 +20,10 @@
         "prisma": "^7.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-markdown": "^10.1.0"
+        "react-globe.gl": "^2.37.0",
+        "react-markdown": "^10.1.0",
+        "resium": "^1.19.2",
+        "three": "^0.182.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -28,6 +32,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
+        "symlink-dir": "^9.0.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5"
@@ -347,6 +352,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -393,6 +407,57 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cesium/engine": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-22.2.0.tgz",
+      "integrity": "sha512-tMy65eWMJ/s0h38jeY5zBaqN5isEyx+u6JPNXNvuafF9FjTDYGjjSevgMr5iKF8LqjaxtQ3/PuWMimjvgv3ECw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cesium/wasm-splats": "^0.1.0-alpha.2",
+        "@spz-loader/core": "0.3.0",
+        "@tweenjs/tween.js": "^25.0.0",
+        "@zip.js/zip.js": "^2.8.1",
+        "autolinker": "^4.0.0",
+        "bitmap-sdf": "^1.0.3",
+        "dompurify": "^3.3.0",
+        "draco3d": "^1.5.1",
+        "earcut": "^3.0.0",
+        "grapheme-splitter": "^1.0.4",
+        "jsep": "^1.3.8",
+        "kdbush": "^4.0.1",
+        "ktx-parse": "^1.0.0",
+        "lerc": "^2.0.0",
+        "mersenne-twister": "^1.1.0",
+        "meshoptimizer": "^1.0.1",
+        "pako": "^2.0.4",
+        "protobufjs": "^8.0.0",
+        "rbush": "^4.0.1",
+        "topojson-client": "^3.1.0",
+        "urijs": "^1.19.7"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@cesium/wasm-splats": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@cesium/wasm-splats/-/wasm-splats-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-t9pMkknv31hhIbLpMa8yPvmqfpvs5UkUjgqlQv9SeO8VerCXOYnyP8/486BDaFrztM0A7FMbRjsXtNeKvqQghA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cesium/widgets": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-14.2.0.tgz",
+      "integrity": "sha512-Q+FrDynEwh1mxtdwN+uFzi2X4qIeoYwq0TnH/sdo0jhTPiM7qNYLiF2jmc0zxHRQFTOR1Sdzk3dqv60qjD0n5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cesium/engine": "^22.2.0",
+        "nosleep.js": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -2043,12 +2108,86 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@spz-loader/core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@spz-loader/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-sbStwMHb/MIE29st7rRuMYWqhX1UmLSFzdpyGtUZUXLkFNIuYKblzjQdtiet8bau8sUf21uL1DQ451zuySGmcA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=8"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2336,6 +2475,55 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.2.tgz",
+      "integrity": "sha512-PAfPDQ0TW1+VLgZ7tReTSyZ/X41AW7/nMRQxVpY+h/aG7JomZJ779lojnODT4dWCn3IMTA3xD2dDDfVYBAQMYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.2",
+        "@turf/invariant": "7.3.2",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.2.tgz",
+      "integrity": "sha512-5HFN42rgWjSobdTMxbuq+ZdXPcqp1IbMgFYULTLCplEQM3dXhsyRFe7DCss4Eiw12iW3q6Z5UeTNVfITsE5lgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.2.tgz",
+      "integrity": "sha512-brGmL1EFhZH/YNXhq6S+8sPWBEnmvEyxMWJO8bUNOFZyWHYiRTwxQHZM+An1blkbQ77PiEzsdNAspZqE1j7YKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.2",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2370,6 +2558,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2413,7 +2607,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2437,6 +2630,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2997,6 +3197,36 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.15",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.15.tgz",
+      "integrity": "sha512-HZKJLFe4eGVgCe9J87PnijY7T1Zn638bEHS+Fm/ygHZozRpefzWcOYfPaP52S8pqk9g4xN3+LzMDl3Lv9dLglA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@zkochan/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-GBf4ua7ogWTr7fATnzk/JLowZDBnBJMm8RkMaC/KcvxZ9gxbMWix0/jImd815LmqKyIHZ7h7lADRddGMdGBuCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3265,6 +3495,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autolinker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-4.1.5.tgz",
+      "integrity": "sha512-vEfYZPmvVOIuE567XBVCsx8SBgOYtjB2+S1iAaJ+HgH+DNjAcrHem2hmAeC9yaNGWayicv4yR+9UaJlkF3pvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "pnpm": ">=10.10.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3335,6 +3577,25 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/bitmap-sdf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -3524,6 +3785,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cesium": {
+      "version": "1.137.0",
+      "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.137.0.tgz",
+      "integrity": "sha512-mi8wMoHkkNWHdhAjyFUURom9r8Y6iUMr2307DwQ24MF3ZXSrL6yhsrTTAT+AiKrwcqEPqoe38y+qrFE0FA7iUg==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "packages/engine",
+        "packages/widgets",
+        "packages/sandcastle"
+      ],
+      "dependencies": {
+        "@cesium/engine": "^22.2.0",
+        "@cesium/widgets": "^14.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3664,6 +3943,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3713,12 +3998,186 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-voronoi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz",
+      "integrity": "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-delaunay": "6",
+        "d3-geo": "3",
+        "d3-tricontour": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tricontour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
+      "integrity": "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-delaunay": "6",
+        "d3-scale": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3862,6 +4321,15 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -3922,6 +4390,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -3933,6 +4410,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3948,6 +4431,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/effect": {
       "version": "3.18.4",
@@ -4840,6 +5329,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4870,6 +5373,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frame-ticker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/frame-ticker/-/frame-ticker-1.0.3.tgz",
+      "integrity": "sha512-E0X2u2JIvbEMrqEg5+4BpTqaD22OwojJI63K7MdKHdncjtAhGRbCR8nJCr2vwEt9NWBPCPcu70X9smPviEBy8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "simplesignal": "^2.1.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -5093,6 +5620,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globe.gl": {
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.45.0.tgz",
+      "integrity": "sha512-fjkLHVBrnbESkUgklTd4UbcGLciu4nIl49IIi1hclLjI6MU3ASu6JYmf/K5qwPf7I+tNOauQRr4i5Y28JTtHQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.154 <1",
+        "three-globe": "^2.45",
+        "three-render-objects": "^1.40"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5117,6 +5661,23 @@
       "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
       "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
       "license": "MIT"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "license": "MIT"
+    },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5347,6 +5908,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -5366,6 +5936,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -5845,6 +6424,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5876,6 +6465,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5898,7 +6496,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5912,6 +6509,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/jsesc": {
@@ -5967,6 +6573,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5983,6 +6602,24 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5992,6 +6629,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/ktx-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-1.1.0.tgz",
+      "integrity": "sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==",
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -6012,6 +6655,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/lerc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-2.0.0.tgz",
+      "integrity": "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg==",
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6319,6 +6968,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6346,7 +7001,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6562,6 +7216,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==",
+      "license": "MIT"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -7242,6 +7908,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nosleep.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nosleep.js/-/nosleep.js-0.12.0.tgz",
+      "integrity": "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==",
+      "license": "MIT"
+    },
     "node_modules/nypm": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
@@ -7274,7 +7946,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7467,6 +8138,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7571,6 +8248,27 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7691,7 +8389,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7724,6 +8421,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
+      "integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -7773,6 +8494,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
+    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -7804,12 +8540,43 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-globe.gl": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.37.0.tgz",
+      "integrity": "sha512-nN1FDOJBhFvWfKrOY0SnkDuA8wk9FSTBN0HFfAdTqqcFM5R+OXBIxK0BM6t8n3oNVYpEJVxEzjYFwLyk4BC7Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "globe.gl": "^2.45",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7943,6 +8710,34 @@
         "type-fest": "^4.39.1"
       }
     },
+    "node_modules/rename-overwrite": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/rename-overwrite/-/rename-overwrite-6.0.3.tgz",
+      "integrity": "sha512-Daqe51STnrCUq/t4dbzCtfNBLElrqVpCtuWK0MuPrzUi6K/13E98y3E8/kzuMZt6IEmghMnF41J0AidrFqjZUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zkochan/rimraf": "^3.0.2",
+        "fs-extra": "11.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resium": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/resium/-/resium-1.19.2.tgz",
+      "integrity": "sha512-JPY/1oPLa0gxt3OQt7I1YF/iwPO9cNkndxhRnQmrwmu9uPGvTKHgbv8q6MTqp/IvFIBx+SVyfUBAUrtvPM9PiQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "cesium": "1.x",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -8003,6 +8798,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -8326,6 +9127,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simplesignal": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/simplesignal/-/simplesignal-2.1.7.tgz",
+      "integrity": "sha512-PEo2qWpUke7IMhlqiBxrulIFvhJRLkl1ih52Rwa+bPjzhJepcd4GIjn2RiQmFSx3dQvsEAgF0/lXMwMN7vODaA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8611,6 +9418,23 @@
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/symlink-dir": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/symlink-dir/-/symlink-dir-9.0.0.tgz",
+      "integrity": "sha512-3i39G70eXo9POjx9RnYAgymfUO3AFrezABaJq0Sh+muMCR3Lx7B9KQR2uWMY+yc1QCwhEelVCGS6N+sR3aKCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "^1.0.0",
+        "rename-overwrite": "^6.0.2"
+      },
+      "bin": {
+        "symlink-dir": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -8632,6 +9456,117 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-conic-polygon-geometry": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-2.1.2.tgz",
+      "integrity": "sha512-NaP3RWLJIyPGI+zyaZwd0Yj6rkoxm4FJHqAX1Enb4L64oNYLCn4bz1ESgOEYavgcUwCNYINu1AgEoUBJr1wZcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^7.2",
+        "d3-array": "1 - 3",
+        "d3-geo": "1 - 3",
+        "d3-geo-voronoi": "2",
+        "d3-scale": "1 - 4",
+        "delaunator": "5",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-geojson-geometry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/three-geojson-geometry/-/three-geojson-geometry-2.1.1.tgz",
+      "integrity": "sha512-dC7bF3ri1goDcihYhzACHOBQqu7YNNazYLa2bSydVIiJUb3jDFojKSy+gNj2pMkqZNSVjssSmdY9zlmnhEpr1w==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "earcut": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.72.0"
+      }
+    },
+    "node_modules/three-globe": {
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.45.0.tgz",
+      "integrity": "sha512-Ur6BVkezvmHnvsEg8fbq6gIscSZtknSQMWwDRbiJ95o6OSDjDbGTc4oO6nP7mOM9aAA3YrF7YZyOwSkP4T56QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "d3-array": "3",
+        "d3-color": "3",
+        "d3-geo": "3",
+        "d3-interpolate": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "data-bind-mapper": "1",
+        "frame-ticker": "1",
+        "h3-js": "4",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "three-conic-polygon-geometry": "2",
+        "three-geojson-geometry": "2",
+        "three-slippy-map-globe": "1",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.40.4",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.40.4.tgz",
+      "integrity": "sha512-Ukpu1pei3L5r809izvjsZxwuRcYLiyn6Uvy3lZ9bpMTdvj3i6PeX6w++/hs2ZS3KnEzGjb6YvTvh4UQuwHTDJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.168"
+      }
+    },
+    "node_modules/three-slippy-map-globe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/three-slippy-map-globe/-/three-slippy-map-globe-1.0.4.tgz",
+      "integrity": "sha512-am8A4PP38AfTdrhXBDucwPRHLTbBl93yhpjIs56K1TLs9VuUWzg68oim4Dibs9QC1riXbj5SoBp/okA1VN9eYg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "1 - 3",
+        "d3-octree": "^1.1",
+        "d3-scale": "1 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.154"
+      }
+    },
     "node_modules/throttleit": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
@@ -8643,6 +9578,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -8712,6 +9653,20 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
       }
     },
     "node_modules/trim-lines": {
@@ -8963,7 +9918,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -9053,6 +10007,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -9128,6 +10092,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
+    "postinstall": "rm -f public/cesium && ln -sf ../node_modules/cesium/Build/Cesium public/cesium",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
@@ -21,6 +22,7 @@
     "@ai-sdk/react": "^3.0.40",
     "@prisma/client": "^7.2.0",
     "ai": "^6.0.38",
+    "cesium": "^1.137.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",
     "next": "16.1.2",
@@ -28,7 +30,10 @@
     "prisma": "^7.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-markdown": "^10.1.0"
+    "react-globe.gl": "^2.37.0",
+    "react-markdown": "^10.1.0",
+    "resium": "^1.19.2",
+    "three": "^0.182.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -37,6 +42,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
+    "symlink-dir": "^9.0.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5"

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,7 +17,7 @@ const searchIntentSchema = z.object({
   activities: z.array(z.string()).describe('Specific activities mentioned like cooking, hiking, tours, etc'),
 });
 
-// System prompt that handles semantic search
+// System prompt that handles semantic search and itinerary planning
 const SYSTEM_PROMPT = `You are a friendly matchmaker for Localhost, a platform that connects travelers with locals and authentic experiences.
 
 Your role depends on the MODE indicated in the user's message:
@@ -33,12 +33,35 @@ Your role depends on the MODE indicated in the user's message:
 - Use semanticSearch with searchType "experiences" to find the best matches
 - The search understands concepts like "touristy things" → history/landmarks/culture
 
+**ITINERARY MODE** (default when no mode specified, or on /itinerary page):
+- Help travelers plan full trip itineraries
+- When they describe a trip, generate a structured itinerary with destinations
+- ALWAYS include a JSON block with destination data for the globe visualization
+- Format destinations with exact coordinates (lat/lng)
+
+Example response format for itinerary:
+"Here's your 5-day Japan itinerary:
+
+**Day 1-2: Tokyo** - Explore Shibuya, Senso-ji Temple, and try street food
+**Day 3-4: Kyoto** - Visit Fushimi Inari and the bamboo grove
+**Day 5: Osaka** - Dotonbori food tour and castle visit
+
+\`\`\`json
+{
+  "destinations": [
+    {"name": "Tokyo", "lat": 35.6762, "lng": 139.6503, "day": 1, "activities": ["Shibuya", "Senso-ji Temple", "Street food"]},
+    {"name": "Kyoto", "lat": 35.0116, "lng": 135.7681, "day": 3, "activities": ["Fushimi Inari", "Bamboo Grove"]},
+    {"name": "Osaka", "lat": 34.6937, "lng": 135.5023, "day": 5, "activities": ["Dotonbori", "Osaka Castle"]}
+  ]
+}
+\`\`\`"
+
 Guidelines:
 - Extract the essence of what they want - don't just use their exact words
 - Think about related concepts (tourist spots = history, landmarks, famous places)
 - After getting results, summarize the top 3-5 matches in a friendly way
-- Use navigate tool to send them to the results page after showing matches
-- Keep responses warm and helpful`;
+- Keep responses warm and helpful
+- For itineraries, ALWAYS include the JSON code block with lat/lng coordinates`;
 
 export async function POST(req: Request) {
   const { messages } = await req.json();

--- a/src/app/itinerary/page.tsx
+++ b/src/app/itinerary/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect } from 'react';
+
+// Dynamic import for Cesium components (no SSR)
+const GlobeItinerary = dynamic(
+  () => import('@/components/features/globe-itinerary'),
+  { 
+    ssr: false,
+    loading: () => (
+      <div className="h-screen flex items-center justify-center bg-[var(--deep-space-blue)]">
+        <div className="text-white text-lg animate-pulse">Loading globe...</div>
+      </div>
+    ),
+  }
+);
+
+export default function ItineraryPage() {
+  // Load Cesium CSS via useEffect since we can't use next/head in client components
+  useEffect(() => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/cesium/Widgets/widgets.css';
+    document.head.appendChild(link);
+    
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  return <GlobeItinerary />;
+}

--- a/src/components/features/add-item-modal.tsx
+++ b/src/components/features/add-item-modal.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { ItineraryItem, ItineraryItemType, ITEM_TYPE_CONFIG } from '@/types/itinerary';
+
+interface AddItemModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (type: ItineraryItemType, title: string, options?: Partial<ItineraryItem>) => void;
+  editingItem?: ItineraryItem | null;
+}
+
+export function AddItemModal({ isOpen, onClose, onSave, editingItem }: AddItemModalProps) {
+  const [type, setType] = useState<ItineraryItemType>('activity');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [location, setLocation] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+
+  // Reset form when opening/editing
+  useEffect(() => {
+    if (editingItem) {
+      setType(editingItem.type);
+      setTitle(editingItem.title);
+      setDescription(editingItem.description || '');
+      setLocation(editingItem.location || '');
+      setStartTime(editingItem.startTime || '');
+      setEndTime(editingItem.endTime || '');
+    } else {
+      setType('activity');
+      setTitle('');
+      setDescription('');
+      setLocation('');
+      setStartTime('');
+      setEndTime('');
+    }
+  }, [editingItem, isOpen]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    onSave(type, title.trim(), {
+      description: description.trim() || undefined,
+      location: location.trim() || undefined,
+      startTime: startTime || undefined,
+      endTime: endTime || undefined,
+    });
+
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div 
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      
+      {/* Modal */}
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden animate-slide-up">
+        {/* Header */}
+        <div className="bg-gradient-to-r from-[var(--blue-green)] to-[var(--sky-blue-dark)] p-4 text-white">
+          <h2 className="text-lg font-semibold">
+            {editingItem ? 'Edit Item' : 'Add New Item'}
+          </h2>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          {/* Type Selector */}
+          <div>
+            <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+              Type
+            </label>
+            <div className="grid grid-cols-5 gap-2">
+              {(Object.keys(ITEM_TYPE_CONFIG) as ItineraryItemType[]).map((itemType) => {
+                const config = ITEM_TYPE_CONFIG[itemType];
+                return (
+                  <button
+                    key={itemType}
+                    type="button"
+                    onClick={() => setType(itemType)}
+                    className={`flex flex-col items-center gap-1 p-2 rounded-lg border-2 transition-all
+                              ${type === itemType 
+                                ? 'border-[var(--blue-green)] bg-[var(--sky-blue-lighter)]/50' 
+                                : 'border-[var(--border)] hover:border-[var(--muted)]'}`}
+                  >
+                    <span className="text-xl">{config.icon}</span>
+                    <span className="text-[10px] text-[var(--muted-foreground)] leading-tight text-center">
+                      {config.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g., Visit Senso-ji Temple"
+              className="w-full px-3 py-2 rounded-lg border border-[var(--border)] 
+                        focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent
+                        placeholder:text-[var(--muted)]"
+              required
+            />
+          </div>
+          
+          {/* Location */}
+          <div>
+            <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+              Location
+            </label>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g., Asakusa, Tokyo"
+              className="w-full px-3 py-2 rounded-lg border border-[var(--border)] 
+                        focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent
+                        placeholder:text-[var(--muted)]"
+            />
+          </div>
+          
+          {/* Time Range */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                Start Time
+              </label>
+              <input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-[var(--border)] 
+                          focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                End Time
+              </label>
+              <input
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-[var(--border)] 
+                          focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent"
+              />
+            </div>
+          </div>
+          
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+              Notes
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Any additional details..."
+              rows={2}
+              className="w-full px-3 py-2 rounded-lg border border-[var(--border)] 
+                        focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent
+                        placeholder:text-[var(--muted)] resize-none"
+            />
+          </div>
+          
+          {/* Actions */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-2.5 px-4 rounded-lg border border-[var(--border)] text-[var(--foreground)]
+                        hover:bg-[var(--sky-blue-lighter)]/30 transition-colors font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex-1 py-2.5 px-4 rounded-lg bg-[var(--princeton-orange)] text-white
+                        hover:bg-[var(--princeton-dark)] transition-colors font-medium"
+            >
+              {editingItem ? 'Save Changes' : 'Add Item'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/cesium-globe.tsx
+++ b/src/components/features/cesium-globe.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useRef, useEffect, useState } from 'react';
+import { GlobeDestination, TravelRoute } from '@/types/globe';
+
+// Set Cesium base URL BEFORE importing Cesium
+if (typeof window !== 'undefined') {
+  (window as any).CESIUM_BASE_URL = '/cesium';
+}
+
+// Now import Cesium and Resium
+import { Viewer, Entity, PolylineGraphics } from 'resium';
+import { 
+  Cartesian3, 
+  Color, 
+  PolylineDashMaterialProperty,
+  UrlTemplateImageryProvider,
+  buildModuleUrl,
+} from 'cesium';
+import type { Viewer as CesiumViewer } from 'cesium';
+
+// Set the module base URL
+buildModuleUrl.setBaseUrl('/cesium/');
+
+// Use OpenStreetMap tiles (no API key required)
+const osmProvider = new UrlTemplateImageryProvider({
+  url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  credit: '© OpenStreetMap contributors',
+});
+
+interface CesiumGlobeProps {
+  destinations: GlobeDestination[];
+  routes: TravelRoute[];
+  selectedDestination?: string | null;
+  onDestinationClick?: (destination: GlobeDestination) => void;
+}
+
+export default function CesiumGlobe({
+  destinations,
+  routes,
+  selectedDestination,
+  onDestinationClick,
+}: CesiumGlobeProps) {
+  const viewerRef = useRef<CesiumViewer | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  // Fly to destination when selected
+  useEffect(() => {
+    if (selectedDestination && viewerRef.current && isReady) {
+      const dest = destinations.find(d => d.id === selectedDestination);
+      if (dest) {
+        viewerRef.current.camera.flyTo({
+          destination: Cartesian3.fromDegrees(dest.lng, dest.lat, 500000),
+          duration: 2,
+        });
+      }
+    }
+  }, [selectedDestination, destinations, isReady]);
+
+  // Fly to first destination on initial load
+  useEffect(() => {
+    if (destinations.length > 0 && viewerRef.current && isReady) {
+      const firstDest = destinations[0];
+      setTimeout(() => {
+        viewerRef.current?.camera.flyTo({
+          destination: Cartesian3.fromDegrees(firstDest.lng, firstDest.lat, 2000000),
+          duration: 3,
+        });
+      }, 500);
+    }
+  }, [destinations.length, isReady]);
+
+  return (
+    <Viewer
+      ref={(e) => {
+        if (e?.cesiumElement && !viewerRef.current) {
+          viewerRef.current = e.cesiumElement;
+          // Use OSM tiles instead of Ion
+          const layers = e.cesiumElement.imageryLayers;
+          layers.removeAll();
+          layers.addImageryProvider(osmProvider);
+          setIsReady(true);
+        }
+      }}
+      full
+      baseLayerPicker={false}
+      geocoder={false}
+      homeButton={false}
+      sceneModePicker={false}
+      timeline={false}
+      animation={false}
+      navigationHelpButton={false}
+      fullscreenButton={false}
+      infoBox={false}
+      selectionIndicator={false}
+      style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+    >
+      {/* Destination markers */}
+      {destinations.map((dest) => (
+        <Entity
+          key={dest.id}
+          name={dest.name}
+          position={Cartesian3.fromDegrees(dest.lng, dest.lat, 0)}
+          point={{
+            pixelSize: selectedDestination === dest.id ? 20 : 14,
+            color: Color.fromCssColorString(dest.color),
+            outlineColor: Color.WHITE,
+            outlineWidth: 2,
+            heightReference: 1, // CLAMP_TO_GROUND
+          }}
+          label={{
+            text: `Day ${dest.day}: ${dest.name}`,
+            font: '14px sans-serif',
+            fillColor: Color.WHITE,
+            outlineColor: Color.BLACK,
+            outlineWidth: 2,
+            style: 2, // FILL_AND_OUTLINE
+            verticalOrigin: 1, // BOTTOM
+            pixelOffset: { x: 0, y: -20 } as any,
+          }}
+          onClick={() => onDestinationClick?.(dest)}
+        />
+      ))}
+
+      {/* Travel routes */}
+      {routes.map((route) => (
+        <Entity key={route.id} name={`${route.fromId} to ${route.toId}`}>
+          <PolylineGraphics
+            positions={Cartesian3.fromDegreesArray([
+              route.fromLng, route.fromLat,
+              route.toLng, route.toLat,
+            ])}
+            width={3}
+            material={
+              new PolylineDashMaterialProperty({
+                color: Color.fromCssColorString('#ffb703'),
+                dashLength: 16,
+              })
+            }
+            clampToGround={false}
+          />
+        </Entity>
+      ))}
+    </Viewer>
+  );
+}

--- a/src/components/features/globe-itinerary.tsx
+++ b/src/components/features/globe-itinerary.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+import { useChat } from '@ai-sdk/react';
+import { 
+  GlobeDestination, 
+  TravelRoute, 
+  SAMPLE_DESTINATIONS, 
+  SAMPLE_ROUTES,
+  generateId,
+  getColorForDay,
+} from '@/types/globe';
+
+// Dynamic import for Cesium (no SSR)
+const CesiumGlobe = dynamic(() => import('./cesium-globe'), { 
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center bg-[var(--deep-space-blue)]">
+      <div className="text-white animate-pulse">Loading globe...</div>
+    </div>
+  ),
+});
+
+export default function GlobeItinerary() {
+  const [destinations, setDestinations] = useState<GlobeDestination[]>([]);
+  const [routes, setRoutes] = useState<TravelRoute[]>([]);
+  const [selectedDestination, setSelectedDestination] = useState<string | null>(null);
+  const [showTimeline, setShowTimeline] = useState(true);
+  const [localInput, setLocalInput] = useState('');
+  const chatEndRef = useRef<HTMLDivElement>(null);
+
+  // AI Chat hook - using the same pattern as chat-widget
+  const { messages, sendMessage, status, error } = useChat();
+  const isLoading = status === 'submitted' || status === 'streaming';
+
+  // Parse AI response for destination data
+  const parseDestinationsFromResponse = useCallback((content: string) => {
+    // Look for JSON blocks in the response
+    const jsonMatch = content.match(/```json\n?([\s\S]*?)\n?```/);
+    if (jsonMatch) {
+      try {
+        const data = JSON.parse(jsonMatch[1]);
+        if (data.destinations && Array.isArray(data.destinations)) {
+          const newDestinations: GlobeDestination[] = data.destinations.map((d: any, i: number) => ({
+            id: generateId(),
+            name: d.name || d.city,
+            lat: d.lat || d.latitude,
+            lng: d.lng || d.longitude || d.lon,
+            day: d.day || i + 1,
+            activities: d.activities || [],
+            color: getColorForDay(d.day || i + 1),
+          }));
+          
+          setDestinations(newDestinations);
+          
+          // Create routes between consecutive destinations
+          const newRoutes: TravelRoute[] = [];
+          for (let i = 0; i < newDestinations.length - 1; i++) {
+            newRoutes.push({
+              id: generateId(),
+              fromId: newDestinations[i].id,
+              toId: newDestinations[i + 1].id,
+              fromLat: newDestinations[i].lat,
+              fromLng: newDestinations[i].lng,
+              toLat: newDestinations[i + 1].lat,
+              toLng: newDestinations[i + 1].lng,
+              mode: 'flight',
+            });
+          }
+          setRoutes(newRoutes);
+          
+          // Select first destination
+          if (newDestinations.length > 0) {
+            setSelectedDestination(newDestinations[0].id);
+          }
+        }
+      } catch {
+        // Not valid JSON, ignore
+      }
+    }
+  }, []);
+
+  // Watch for new messages and parse destinations
+  useEffect(() => {
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage?.role === 'assistant' && lastMessage.parts) {
+      const textContent = lastMessage.parts
+        .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+        .map((part) => part.text)
+        .join('');
+      
+      if (textContent) {
+        parseDestinationsFromResponse(textContent);
+      }
+    }
+  }, [messages, parseDestinationsFromResponse]);
+
+  // Scroll chat to bottom
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Load sample data for demo
+  const loadSampleData = () => {
+    setDestinations(SAMPLE_DESTINATIONS);
+    setRoutes(SAMPLE_ROUTES);
+    setSelectedDestination(SAMPLE_DESTINATIONS[0].id);
+  };
+
+  // Handle form submit
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!localInput.trim()) return;
+    
+    const content = localInput;
+    setLocalInput('');
+    await sendMessage({ text: content });
+  };
+
+  // Extract text content from message parts
+  const getMessageText = (message: typeof messages[0]): string => {
+    if (!message.parts) return '';
+    return message.parts
+      .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+      .map((part) => part.text)
+      .join('');
+  };
+
+  return (
+    <div className="h-screen flex flex-col bg-[var(--deep-space-blue)]">
+      {/* Header */}
+      <header className="flex-shrink-0 bg-[var(--background)]/95 backdrop-blur-md border-b border-[var(--border)] px-4 py-3 z-20">
+        <div className="flex items-center justify-between max-w-7xl mx-auto">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">🌍</span>
+            <h1 className="font-bold text-xl text-[var(--foreground)]">Trip Planner</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={loadSampleData}
+              className="px-3 py-1.5 text-sm rounded-lg bg-[var(--sky-blue-lighter)]/30 text-[var(--foreground)] hover:bg-[var(--sky-blue-lighter)]/50 transition-colors"
+            >
+              Load Demo
+            </button>
+            <button
+              onClick={() => setShowTimeline(!showTimeline)}
+              className="px-3 py-1.5 text-sm rounded-lg bg-[var(--sky-blue-lighter)]/30 text-[var(--foreground)] hover:bg-[var(--sky-blue-lighter)]/50 transition-colors"
+            >
+              {showTimeline ? 'Hide' : 'Show'} Timeline
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Globe */}
+        <div className="flex-1 relative">
+          <CesiumGlobe
+            destinations={destinations}
+            routes={routes}
+            selectedDestination={selectedDestination}
+            onDestinationClick={(dest) => setSelectedDestination(dest.id)}
+          />
+        </div>
+
+        {/* Chat Panel */}
+        <div className="w-[400px] flex-shrink-0 bg-[var(--background)] border-l border-[var(--border)] flex flex-col">
+          {/* Chat header */}
+          <div className="flex-shrink-0 bg-gradient-to-r from-[var(--princeton-orange)] to-[var(--blue-green)] px-4 py-3">
+            <h2 className="text-white font-semibold">✈️ Plan Your Trip</h2>
+            <p className="text-white/80 text-sm">Tell me where you want to go!</p>
+          </div>
+
+          {/* Chat messages */}
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            {messages.length === 0 && (
+              <div className="text-center py-8">
+                <p className="text-[var(--muted-foreground)]">
+                  🌍 Tell me about your dream trip!
+                </p>
+                <p className="text-sm text-[var(--muted)] mt-2">
+                  Try: "Plan a 5-day trip to Japan"
+                </p>
+              </div>
+            )}
+            
+            {messages.map((message) => {
+              const textContent = getMessageText(message);
+              if (!textContent) return null;
+              
+              return (
+                <div
+                  key={message.id}
+                  className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-2xl px-4 py-2.5 ${
+                      message.role === 'user'
+                        ? 'bg-[var(--princeton-orange)] text-white'
+                        : 'bg-[var(--sky-blue-lighter)]/30 text-[var(--foreground)]'
+                    }`}
+                  >
+                    <div className="text-sm whitespace-pre-wrap">{textContent}</div>
+                  </div>
+                </div>
+              );
+            })}
+            
+            {isLoading && (
+              <div className="flex justify-start">
+                <div className="bg-[var(--sky-blue-lighter)]/30 rounded-2xl px-4 py-2.5">
+                  <div className="flex gap-1">
+                    <span className="w-2 h-2 bg-[var(--muted)] rounded-full animate-bounce" />
+                    <span className="w-2 h-2 bg-[var(--muted)] rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                    <span className="w-2 h-2 bg-[var(--muted)] rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                  </div>
+                </div>
+              </div>
+            )}
+            
+            {error && (
+              <div className="text-center py-2 text-red-500 text-sm">
+                Something went wrong. Please try again.
+              </div>
+            )}
+            
+            <div ref={chatEndRef} />
+          </div>
+
+          {/* Chat input */}
+          <form onSubmit={handleSubmit} className="flex-shrink-0 p-4 border-t border-[var(--border)]">
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={localInput}
+                onChange={(e) => setLocalInput(e.target.value)}
+                placeholder="Plan a trip to..."
+                className="flex-1 px-4 py-2.5 rounded-xl border border-[var(--border)] bg-white
+                          focus:outline-none focus:ring-2 focus:ring-[var(--blue-green)] focus:border-transparent
+                          placeholder:text-[var(--muted)]"
+                disabled={isLoading}
+              />
+              <button
+                type="submit"
+                disabled={isLoading || !localInput.trim()}
+                className="px-4 py-2.5 rounded-xl bg-[var(--princeton-orange)] text-white font-medium
+                          hover:bg-[var(--princeton-dark)] disabled:opacity-50 disabled:cursor-not-allowed
+                          transition-colors"
+              >
+                Send
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      {showTimeline && destinations.length > 0 && (
+        <div className="flex-shrink-0 bg-[var(--background)] border-t border-[var(--border)] p-4">
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {destinations.map((dest) => (
+              <button
+                key={dest.id}
+                onClick={() => setSelectedDestination(dest.id)}
+                className={`flex-shrink-0 px-4 py-2 rounded-lg border-2 transition-all ${
+                  selectedDestination === dest.id
+                    ? 'border-[var(--princeton-orange)] bg-[var(--princeton-orange)]/10'
+                    : 'border-[var(--border)] hover:border-[var(--blue-green)]'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: dest.color }}
+                  />
+                  <span className="font-medium text-[var(--foreground)]">
+                    Day {dest.day}: {dest.name}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/index.ts
+++ b/src/components/features/index.ts
@@ -16,3 +16,7 @@ export { BookingSummary } from './booking-summary';
 export { ChatMessage } from './chat-message';
 export { ChatWidget } from './chat-widget';
 export { ConditionalChatWidget } from './conditional-chat-widget';
+export { ItineraryBuilder } from './itinerary-builder';
+export { ItineraryDayColumn } from './itinerary-day';
+export { ItineraryItem } from './itinerary-item';
+export { AddItemModal } from './add-item-modal';

--- a/src/components/features/itinerary-builder.tsx
+++ b/src/components/features/itinerary-builder.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Itinerary, ItineraryItem, ItineraryItemType } from '@/types/itinerary';
+import { ItineraryDayColumn } from './itinerary-day';
+import { AddItemModal } from './add-item-modal';
+
+interface ItineraryBuilderProps {
+  itinerary: Itinerary;
+  onAddItem: (dayId: string, type: ItineraryItemType, title: string, options?: Partial<ItineraryItem>) => void;
+  onUpdateItem: (dayId: string, itemId: string, updates: Partial<ItineraryItem>) => void;
+  onDeleteItem: (dayId: string, itemId: string) => void;
+  onReorderItem: (fromDayId: string, toDayId: string, itemId: string, newPosition: number) => void;
+  onDelete: () => void;
+}
+
+interface DragData {
+  dayId: string;
+  item: ItineraryItem;
+}
+
+export function ItineraryBuilder({
+  itinerary,
+  onAddItem,
+  onUpdateItem,
+  onDeleteItem,
+  onReorderItem,
+  onDelete,
+}: ItineraryBuilderProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedDayId, setSelectedDayId] = useState<string | null>(null);
+  const [editingItem, setEditingItem] = useState<{ dayId: string; item: ItineraryItem } | null>(null);
+  const [dragData, setDragData] = useState<DragData | null>(null);
+
+  // Format dates for display
+  const formatDateRange = () => {
+    const start = new Date(itinerary.startDate + 'T00:00:00');
+    const end = new Date(itinerary.endDate + 'T00:00:00');
+    const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+    return `${start.toLocaleDateString('en-US', options)} - ${end.toLocaleDateString('en-US', options)}`;
+  };
+
+  // Drag and Drop handlers
+  const handleDragStart = useCallback((e: React.DragEvent, dayId: string, item: ItineraryItem) => {
+    setDragData({ dayId, item });
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', item.id); // Required for Firefox
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent, targetDayId: string) => {
+    e.preventDefault();
+    
+    if (!dragData) return;
+    
+    // Get drop position based on mouse position
+    const targetDay = itinerary.days.find(d => d.id === targetDayId);
+    const newPosition = targetDay ? targetDay.items.length : 0;
+    
+    onReorderItem(dragData.dayId, targetDayId, dragData.item.id, newPosition);
+    setDragData(null);
+  }, [dragData, itinerary.days, onReorderItem]);
+
+  // Modal handlers
+  const handleAddClick = (dayId: string) => {
+    setSelectedDayId(dayId);
+    setEditingItem(null);
+    setIsModalOpen(true);
+  };
+
+  const handleEditClick = (dayId: string, item: ItineraryItem) => {
+    setSelectedDayId(dayId);
+    setEditingItem({ dayId, item });
+    setIsModalOpen(true);
+  };
+
+  const handleModalSave = (type: ItineraryItemType, title: string, options?: Partial<ItineraryItem>) => {
+    if (editingItem) {
+      onUpdateItem(editingItem.dayId, editingItem.item.id, { type, title, ...options });
+    } else if (selectedDayId) {
+      onAddItem(selectedDayId, type, title, options);
+    }
+    setIsModalOpen(false);
+    setEditingItem(null);
+    setSelectedDayId(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      {/* Header */}
+      <div className="bg-white border-b border-[var(--border)] sticky top-0 z-10">
+        <div className="max-w-7xl mx-auto px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-bold text-[var(--foreground)]">
+                {itinerary.title}
+              </h1>
+              <div className="flex items-center gap-3 mt-1 text-sm text-[var(--muted-foreground)]">
+                <span className="flex items-center gap-1">
+                  📍 {itinerary.destination}
+                </span>
+                <span className="flex items-center gap-1">
+                  📅 {formatDateRange()}
+                </span>
+                <span className="flex items-center gap-1">
+                  {itinerary.days.length} {itinerary.days.length === 1 ? 'day' : 'days'}
+                </span>
+              </div>
+            </div>
+            <button
+              onClick={onDelete}
+              className="px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
+              Delete Itinerary
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Days Container */}
+      <div className="p-4 overflow-x-auto">
+        <div className="flex gap-4 min-w-max pb-4">
+          {itinerary.days.map((day) => (
+            <ItineraryDayColumn
+              key={day.id}
+              day={day}
+              onAddItem={handleAddClick}
+              onEditItem={handleEditClick}
+              onDeleteItem={onDeleteItem}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Add/Edit Modal */}
+      <AddItemModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditingItem(null);
+          setSelectedDayId(null);
+        }}
+        onSave={handleModalSave}
+        editingItem={editingItem?.item}
+      />
+    </div>
+  );
+}

--- a/src/components/features/itinerary-day.tsx
+++ b/src/components/features/itinerary-day.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import { ItineraryDay as ItineraryDayType, ItineraryItem as ItineraryItemType } from '@/types/itinerary';
+import { ItineraryItem } from './itinerary-item';
+
+interface ItineraryDayProps {
+  day: ItineraryDayType;
+  onAddItem: (dayId: string) => void;
+  onEditItem: (dayId: string, item: ItineraryItemType) => void;
+  onDeleteItem: (dayId: string, itemId: string) => void;
+  onDragStart: (e: React.DragEvent, dayId: string, item: ItineraryItemType) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent, dayId: string) => void;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+export function ItineraryDayColumn({
+  day,
+  onAddItem,
+  onEditItem,
+  onDeleteItem,
+  onDragStart,
+  onDragOver,
+  onDrop,
+}: ItineraryDayProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+    onDragOver(e);
+  };
+  
+  const handleDragLeave = () => {
+    setIsDragOver(false);
+  };
+  
+  const handleDrop = (e: React.DragEvent) => {
+    setIsDragOver(false);
+    onDrop(e, day.id);
+  };
+
+  return (
+    <div 
+      className={`flex-shrink-0 w-72 bg-[var(--sky-blue-lighter)]/30 rounded-xl p-3 
+                  transition-all duration-200 ${isDragOver ? 'ring-2 ring-[var(--blue-green)] bg-[var(--sky-blue-lighter)]/50' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* Day Header */}
+      <div className="mb-3">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold text-[var(--princeton-orange)] uppercase tracking-wide">
+            Day {day.dayNumber}
+          </span>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {day.items.length} {day.items.length === 1 ? 'item' : 'items'}
+          </span>
+        </div>
+        <h3 className="font-semibold text-[var(--foreground)] mt-0.5">
+          {formatDate(day.date)}
+        </h3>
+      </div>
+      
+      {/* Items */}
+      <div className="space-y-2 min-h-[100px]">
+        {day.items.length === 0 ? (
+          <div className="text-center py-8 text-[var(--muted-foreground)] text-sm">
+            <p>No activities yet</p>
+            <p className="text-xs mt-1">Add your first item!</p>
+          </div>
+        ) : (
+          day.items
+            .sort((a, b) => a.position - b.position)
+            .map(item => (
+              <ItineraryItem
+                key={item.id}
+                item={item}
+                dayId={day.id}
+                onEdit={(item) => onEditItem(day.id, item)}
+                onDelete={onDeleteItem}
+                onDragStart={onDragStart}
+              />
+            ))
+        )}
+      </div>
+      
+      {/* Add Item Button */}
+      <button
+        onClick={() => onAddItem(day.id)}
+        className="mt-3 w-full py-2 px-3 rounded-lg border-2 border-dashed border-[var(--border)] 
+                   text-[var(--muted-foreground)] text-sm font-medium
+                   hover:border-[var(--blue-green)] hover:text-[var(--blue-green)] hover:bg-white/50
+                   transition-all duration-200 flex items-center justify-center gap-1"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Item
+      </button>
+    </div>
+  );
+}

--- a/src/components/features/itinerary-item.tsx
+++ b/src/components/features/itinerary-item.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { ItineraryItem as ItineraryItemType, ITEM_TYPE_CONFIG } from '@/types/itinerary';
+
+interface ItineraryItemProps {
+  item: ItineraryItemType;
+  dayId: string;
+  onEdit: (item: ItineraryItemType) => void;
+  onDelete: (dayId: string, itemId: string) => void;
+  onDragStart: (e: React.DragEvent, dayId: string, item: ItineraryItemType) => void;
+}
+
+export function ItineraryItem({ 
+  item, 
+  dayId, 
+  onEdit, 
+  onDelete, 
+  onDragStart 
+}: ItineraryItemProps) {
+  const config = ITEM_TYPE_CONFIG[item.type];
+  
+  return (
+    <div
+      draggable
+      onDragStart={(e) => onDragStart(e, dayId, item)}
+      className="group bg-white rounded-lg p-3 shadow-sm border border-[var(--border)] 
+                 hover:shadow-md hover:border-[var(--blue-green)] transition-all duration-200
+                 cursor-grab active:cursor-grabbing"
+    >
+      {/* Header: Type icon + Title */}
+      <div className="flex items-start gap-2">
+        <span 
+          className="flex-shrink-0 w-8 h-8 rounded-lg flex items-center justify-center text-lg"
+          style={{ backgroundColor: `${config.color}20` }}
+        >
+          {config.icon}
+        </span>
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-[var(--foreground)] text-sm truncate">
+            {item.title}
+          </h4>
+          {item.location && (
+            <p className="text-xs text-[var(--muted-foreground)] truncate mt-0.5">
+              📍 {item.location}
+            </p>
+          )}
+        </div>
+      </div>
+      
+      {/* Time */}
+      {(item.startTime || item.endTime) && (
+        <div className="mt-2 text-xs text-[var(--muted-foreground)]">
+          🕐 {item.startTime || '??:??'} - {item.endTime || '??:??'}
+        </div>
+      )}
+      
+      {/* Description preview */}
+      {item.description && (
+        <p className="mt-2 text-xs text-[var(--muted-foreground)] line-clamp-2">
+          {item.description}
+        </p>
+      )}
+      
+      {/* Actions (visible on hover) */}
+      <div className="mt-2 pt-2 border-t border-[var(--border)] flex justify-end gap-1 
+                      opacity-0 group-hover:opacity-100 transition-opacity">
+        <button
+          onClick={() => onEdit(item)}
+          className="p-1.5 rounded-md hover:bg-[var(--sky-blue-lighter)] text-[var(--muted-foreground)] 
+                     hover:text-[var(--blue-green)] transition-colors"
+          title="Edit"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+          </svg>
+        </button>
+        <button
+          onClick={() => onDelete(dayId, item.id)}
+          className="p-1.5 rounded-md hover:bg-red-50 text-[var(--muted-foreground)] 
+                     hover:text-red-600 transition-colors"
+          title="Delete"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/navbar.tsx
+++ b/src/components/features/navbar.tsx
@@ -21,10 +21,13 @@ export function Navbar() {
 
           {/* Navigation Links */}
           <div className="hidden md:flex items-center gap-8">
-            <Link href="/how-it-works" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
-              How It Works
+            <Link href="/explore" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
+              Explore
             </Link>
-            <Link href="/host" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
+            <Link href="/itinerary" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
+              Itinerary
+            </Link>
+            <Link href="/hosts" className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
               Become a Host
             </Link>
           </div>

--- a/src/hooks/useItinerary.ts
+++ b/src/hooks/useItinerary.ts
@@ -1,0 +1,245 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { 
+  Itinerary, 
+  ItineraryDay, 
+  ItineraryItem, 
+  ItineraryItemType,
+  createItinerary as createNewItinerary,
+  createItem,
+  generateId 
+} from '@/types/itinerary';
+
+const STORAGE_KEY = 'localhost_itineraries';
+
+// Get all itineraries from local storage
+function getStoredItineraries(): Itinerary[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+// Save all itineraries to local storage
+function saveItineraries(itineraries: Itinerary[]): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(itineraries));
+}
+
+// Get a specific itinerary by ID
+function getItineraryById(id: string): Itinerary | null {
+  const itineraries = getStoredItineraries();
+  return itineraries.find(i => i.id === id) || null;
+}
+
+// Save a single itinerary (create or update)
+function saveItinerary(itinerary: Itinerary): void {
+  const itineraries = getStoredItineraries();
+  const index = itineraries.findIndex(i => i.id === itinerary.id);
+  
+  if (index >= 0) {
+    itineraries[index] = { ...itinerary, updatedAt: new Date().toISOString() };
+  } else {
+    itineraries.push(itinerary);
+  }
+  
+  saveItineraries(itineraries);
+}
+
+// Delete an itinerary
+function deleteItineraryFromStorage(id: string): void {
+  const itineraries = getStoredItineraries();
+  saveItineraries(itineraries.filter(i => i.id !== id));
+}
+
+export interface UseItineraryReturn {
+  itinerary: Itinerary | null;
+  isLoading: boolean;
+  createItinerary: (title: string, destination: string, startDate: string, endDate: string) => Itinerary;
+  loadItinerary: (id: string) => void;
+  addItem: (dayId: string, type: ItineraryItemType, title: string, options?: Partial<ItineraryItem>) => void;
+  updateItem: (dayId: string, itemId: string, updates: Partial<ItineraryItem>) => void;
+  deleteItem: (dayId: string, itemId: string) => void;
+  reorderItem: (fromDayId: string, toDayId: string, itemId: string, newPosition: number) => void;
+  deleteItinerary: () => void;
+  allItineraries: Itinerary[];
+}
+
+export function useItinerary(initialId?: string): UseItineraryReturn {
+  const [itinerary, setItinerary] = useState<Itinerary | null>(null);
+  const [allItineraries, setAllItineraries] = useState<Itinerary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load itinerary on mount
+  useEffect(() => {
+    setAllItineraries(getStoredItineraries());
+    if (initialId) {
+      const stored = getItineraryById(initialId);
+      setItinerary(stored);
+    }
+    setIsLoading(false);
+  }, [initialId]);
+
+  // Auto-save when itinerary changes
+  useEffect(() => {
+    if (itinerary) {
+      saveItinerary(itinerary);
+      setAllItineraries(getStoredItineraries());
+    }
+  }, [itinerary]);
+
+  const createItinerary = useCallback((
+    title: string, 
+    destination: string, 
+    startDate: string, 
+    endDate: string
+  ): Itinerary => {
+    const newItinerary = createNewItinerary(title, destination, startDate, endDate);
+    setItinerary(newItinerary);
+    return newItinerary;
+  }, []);
+
+  const loadItinerary = useCallback((id: string) => {
+    const stored = getItineraryById(id);
+    setItinerary(stored);
+  }, []);
+
+  const addItem = useCallback((
+    dayId: string, 
+    type: ItineraryItemType, 
+    title: string,
+    options?: Partial<ItineraryItem>
+  ) => {
+    setItinerary(prev => {
+      if (!prev) return prev;
+      
+      return {
+        ...prev,
+        days: prev.days.map(day => {
+          if (day.id !== dayId) return day;
+          
+          const newPosition = day.items.length;
+          const newItem = createItem(type, title, newPosition, options);
+          
+          return {
+            ...day,
+            items: [...day.items, newItem],
+          };
+        }),
+      };
+    });
+  }, []);
+
+  const updateItem = useCallback((dayId: string, itemId: string, updates: Partial<ItineraryItem>) => {
+    setItinerary(prev => {
+      if (!prev) return prev;
+      
+      return {
+        ...prev,
+        days: prev.days.map(day => {
+          if (day.id !== dayId) return day;
+          
+          return {
+            ...day,
+            items: day.items.map(item => 
+              item.id === itemId ? { ...item, ...updates } : item
+            ),
+          };
+        }),
+      };
+    });
+  }, []);
+
+  const deleteItem = useCallback((dayId: string, itemId: string) => {
+    setItinerary(prev => {
+      if (!prev) return prev;
+      
+      return {
+        ...prev,
+        days: prev.days.map(day => {
+          if (day.id !== dayId) return day;
+          
+          const filteredItems = day.items.filter(item => item.id !== itemId);
+          // Re-index positions
+          return {
+            ...day,
+            items: filteredItems.map((item, index) => ({ ...item, position: index })),
+          };
+        }),
+      };
+    });
+  }, []);
+
+  const reorderItem = useCallback((
+    fromDayId: string, 
+    toDayId: string, 
+    itemId: string, 
+    newPosition: number
+  ) => {
+    setItinerary(prev => {
+      if (!prev) return prev;
+      
+      // Find the item
+      let movedItem: ItineraryItem | null = null;
+      
+      const updatedDays = prev.days.map(day => {
+        if (day.id === fromDayId) {
+          const item = day.items.find(i => i.id === itemId);
+          if (item) movedItem = { ...item };
+          
+          const filteredItems = day.items.filter(i => i.id !== itemId);
+          return {
+            ...day,
+            items: filteredItems.map((item, index) => ({ ...item, position: index })),
+          };
+        }
+        return day;
+      });
+      
+      if (!movedItem) return prev;
+      
+      // Insert into target day
+      return {
+        ...prev,
+        days: updatedDays.map(day => {
+          if (day.id !== toDayId) return day;
+          
+          const items = [...day.items];
+          const insertAt = Math.min(Math.max(0, newPosition), items.length);
+          items.splice(insertAt, 0, { ...movedItem!, position: insertAt });
+          
+          // Re-index all positions
+          return {
+            ...day,
+            items: items.map((item, index) => ({ ...item, position: index })),
+          };
+        }),
+      };
+    });
+  }, []);
+
+  const deleteItinerary = useCallback(() => {
+    if (itinerary) {
+      deleteItineraryFromStorage(itinerary.id);
+      setItinerary(null);
+      setAllItineraries(getStoredItineraries());
+    }
+  }, [itinerary]);
+
+  return {
+    itinerary,
+    isLoading,
+    createItinerary,
+    loadItinerary,
+    addItem,
+    updateItem,
+    deleteItem,
+    reorderItem,
+    deleteItinerary,
+    allItineraries,
+  };
+}

--- a/src/lib/data/generate-hosts.ts
+++ b/src/lib/data/generate-hosts.ts
@@ -1,0 +1,166 @@
+// Script to generate fake host profiles
+// Run with: npx ts-node src/lib/data/generate-hosts.ts
+
+const FIRST_NAMES = ['Emma', 'Liam', 'Sofia', 'Noah', 'Olivia', 'Lucas', 'Ava', 'Mason', 'Isabella', 'Ethan', 'Mia', 'Aiden', 'Luna', 'Leo', 'Aria', 'James', 'Chloe', 'Benjamin', 'Ella', 'Jack', 'Amara', 'Kofi', 'Yuki', 'Chen', 'Priya', 'Mohammed', 'Fatima', 'Raj', 'Mei', 'Omar', 'Zara', 'Diego', 'Carmen', 'Luis', 'Ana', 'Marco', 'Giulia', 'Hans', 'Ingrid', 'Sven', 'Freya', 'Kenji', 'Sakura', 'Hiroshi', 'Yuna', 'Jin', 'Min', 'Tao', 'Wei', 'Aisha'];
+const LAST_NAMES = ['Smith', 'Garcia', 'Kim', 'Patel', 'Chen', 'Nguyen', 'Mueller', 'Silva', 'Santos', 'Yamamoto', 'Tanaka', 'Park', 'Lee', 'Wang', 'Ali', 'Hassan', 'Rossi', 'Ferrari', 'Schmidt', 'Weber', 'Johansson', 'Andersen', 'Larsen', 'Okonkwo', 'Mensah', 'Delgado', 'Hernandez', 'Lopez', 'Martinez', 'Rodriguez'];
+
+const CITIES = [
+  { city: 'Tokyo', country: 'Japan' }, { city: 'Paris', country: 'France' }, { city: 'New York', country: 'USA' },
+  { city: 'London', country: 'UK' }, { city: 'Barcelona', country: 'Spain' }, { city: 'Rome', country: 'Italy' },
+  { city: 'Berlin', country: 'Germany' }, { city: 'Amsterdam', country: 'Netherlands' }, { city: 'Lisbon', country: 'Portugal' },
+  { city: 'Sydney', country: 'Australia' }, { city: 'Melbourne', country: 'Australia' }, { city: 'Bangkok', country: 'Thailand' },
+  { city: 'Seoul', country: 'South Korea' }, { city: 'Singapore', country: 'Singapore' }, { city: 'Dubai', country: 'UAE' },
+  { city: 'Cape Town', country: 'South Africa' }, { city: 'Marrakech', country: 'Morocco' }, { city: 'Cairo', country: 'Egypt' },
+  { city: 'Mumbai', country: 'India' }, { city: 'Delhi', country: 'India' }, { city: 'Buenos Aires', country: 'Argentina' },
+  { city: 'Rio de Janeiro', country: 'Brazil' }, { city: 'Mexico City', country: 'Mexico' }, { city: 'Bogota', country: 'Colombia' },
+  { city: 'Lima', country: 'Peru' }, { city: 'Havana', country: 'Cuba' }, { city: 'San Juan', country: 'Puerto Rico' },
+  { city: 'Stockholm', country: 'Sweden' }, { city: 'Copenhagen', country: 'Denmark' }, { city: 'Oslo', country: 'Norway' },
+  { city: 'Vienna', country: 'Austria' }, { city: 'Prague', country: 'Czech Republic' }, { city: 'Budapest', country: 'Hungary' },
+  { city: 'Athens', country: 'Greece' }, { city: 'Istanbul', country: 'Turkey' }, { city: 'Tel Aviv', country: 'Israel' },
+  { city: 'Accra', country: 'Ghana' }, { city: 'Lagos', country: 'Nigeria' }, { city: 'Nairobi', country: 'Kenya' },
+  { city: 'Kyoto', country: 'Japan' }, { city: 'Osaka', country: 'Japan' }, { city: 'Florence', country: 'Italy' },
+  { city: 'Milan', country: 'Italy' }, { city: 'Vancouver', country: 'Canada' }, { city: 'Montreal', country: 'Canada' },
+  { city: 'Toronto', country: 'Canada' }, { city: 'San Francisco', country: 'USA' }, { city: 'Los Angeles', country: 'USA' },
+  { city: 'Chicago', country: 'USA' }, { city: 'New Orleans', country: 'USA' },
+];
+
+const INTEREST_SETS = [
+  ['cooking', 'wine', 'farmers markets', 'food history'],
+  ['street art', 'urban exploration', 'photography', 'graffiti'],
+  ['hiking', 'nature', 'wildlife', 'camping'],
+  ['nightlife', 'cocktails', 'live music', 'dancing'],
+  ['meditation', 'yoga', 'wellness', 'mindfulness'],
+  ['history', 'architecture', 'museums', 'walking tours'],
+  ['surfing', 'beach', 'water sports', 'diving'],
+  ['music', 'jazz', 'local bands', 'concerts'],
+  ['coffee', 'cafes', 'barista skills', 'roasting'],
+  ['vintage shops', 'antiques', 'flea markets', 'thrifting'],
+  ['craft beer', 'breweries', 'pub crawls', 'tasting'],
+  ['street food', 'night markets', 'local eats', 'food tours'],
+  ['cycling', 'bike tours', 'urban cycling', 'mountain biking'],
+  ['photography', 'instagram spots', 'golden hour', 'portraits'],
+  ['traditional crafts', 'pottery', 'weaving', 'artisan workshops'],
+  ['tea ceremonies', 'traditional culture', 'temples', 'spirituality'],
+  ['fashion', 'shopping', 'local designers', 'boutiques'],
+  ['gardening', 'urban farms', 'sustainability', 'permaculture'],
+  ['sailing', 'boats', 'coastal tours', 'fishing'],
+  ['rock climbing', 'bouldering', 'adventure sports', 'adrenaline'],
+];
+
+const CATEGORIES = ['food-drink', 'arts-culture', 'outdoor-adventure', 'nightlife-social', 'wellness', 'learning'] as const;
+
+const EXPERIENCE_TEMPLATES = {
+  'food-drink': [
+    { title: 'Secret {adj} Food Tour', desc: 'Discover hidden gems where locals actually eat' },
+    { title: '{adj} Cooking Class', desc: 'Learn to make authentic dishes in my home kitchen' },
+    { title: 'Wine & {noun} Evening', desc: 'Sample the best local wines paired with delicious bites' },
+    { title: 'Market Tour & {noun}', desc: 'Explore the morning market and cook what we find' },
+  ],
+  'arts-culture': [
+    { title: 'Hidden {noun} Walking Tour', desc: 'See the art and history tourists miss' },
+    { title: '{adj} Street Art Safari', desc: 'Discover murals and meet local artists' },
+    { title: 'Museum Insider {noun}', desc: 'Skip the crowds with a local expert' },
+    { title: '{adj} Architecture Walk', desc: 'Explore iconic and hidden architectural gems' },
+  ],
+  'outdoor-adventure': [
+    { title: 'Sunrise {noun} Adventure', desc: 'Early morning escape to breathtaking views' },
+    { title: '{adj} Nature Hike', desc: 'Discover trails only locals know about' },
+    { title: 'Coastal {noun} Experience', desc: 'Explore stunning coastline and hidden beaches' },
+    { title: '{adj} Bike Tour', desc: 'Cycle through scenic routes and secret spots' },
+  ],
+  'nightlife-social': [
+    { title: 'Secret {noun} Crawl', desc: 'Hit the best spots locals love after dark' },
+    { title: '{adj} Rooftop Night', desc: 'Experience the city skyline at its best' },
+    { title: 'Live Music & {noun}', desc: 'Discover the local music scene' },
+    { title: '{adj} Night Market Tour', desc: 'Experience the city when it comes alive' },
+  ],
+  'wellness': [
+    { title: 'Morning {noun} Session', desc: 'Start your day with peaceful practice' },
+    { title: '{adj} Meditation Walk', desc: 'Find inner peace in sacred spaces' },
+    { title: 'Spa & {noun} Day', desc: 'Traditional wellness rituals and relaxation' },
+    { title: '{adj} Yoga Retreat', desc: 'Mindful movement in beautiful settings' },
+  ],
+  'learning': [
+    { title: '{adj} Photography Walk', desc: 'Capture stunning shots with a local pro' },
+    { title: 'Language & {noun} Exchange', desc: 'Learn local phrases over coffee' },
+    { title: '{adj} Craft Workshop', desc: 'Create something beautiful to take home' },
+    { title: 'Local {noun} Masterclass', desc: 'Learn skills from a passionate expert' },
+  ],
+};
+
+const ADJECTIVES = ['Hidden', 'Secret', 'Authentic', 'Local', 'Traditional', 'Scenic', 'Vibrant', 'Magical', 'Urban', 'Peaceful'];
+const NOUNS = ['Gems', 'Spots', 'Experience', 'Adventure', 'Journey', 'Discovery', 'Escape', 'Tour', 'Culture', 'Vibes'];
+
+const PHOTOS = [
+  'photo-1438761681033-6461ffad8d80', 'photo-1507003211169-0a1dd7228f2d', 'photo-1494790108377-be9c29b29330',
+  'photo-1534528741775-53994a69daeb', 'photo-1500648767791-00dcc994a43e', 'photo-1580489944761-15a19d654956',
+  'photo-1539571696357-5a69c17a67c6', 'photo-1517841905240-472988babdf9', 'photo-1524504388940-b1c1722653e1',
+  'photo-1506794778202-cad84cf45f1d', 'photo-1544005313-94ddf0286df2', 'photo-1531746020798-e6953c6e8e04',
+  'photo-1507591064344-4c6ce005b128', 'photo-1463453091185-61582044d556', 'photo-1519085360753-af0119f7cbe7',
+  'photo-1488426862026-3ee34a7d66df', 'photo-1487412720507-e7ab37603c6f', 'photo-1502685104226-ee32379fefbe',
+  'photo-1472099645785-5658abf4ff4e', 'photo-1519345182560-3f2917c472ef',
+];
+
+const EXP_PHOTOS = {
+  'food-drink': ['photo-1556910103-1c02745aae4d', 'photo-1551024709-8f23befc6f87', 'photo-1414235077428-338989a2e8c0'],
+  'arts-culture': ['photo-1518998053901-5348d3961a04', 'photo-1548707309-dcebeab9ea9b', 'photo-1499781350541-7783f6c6a0c8'],
+  'outdoor-adventure': ['photo-1501785888041-af3ef285b470', 'photo-1469474968028-56623f02e42e', 'photo-1506905925346-21bda4d32df4'],
+  'nightlife-social': ['photo-1514525253161-7a46d19cd819', 'photo-1470225620780-dba8ba36b745', 'photo-1516450360452-9312f5e86fc7'],
+  'wellness': ['photo-1503899036084-c55cdd92da26', 'photo-1544367567-0f2fcb009e0b', 'photo-1506126613408-eca07ce68773'],
+  'learning': ['photo-1452587925148-ce544e77e70d', 'photo-1513475382585-d06e58bcb0e0', 'photo-1460518451285-97b6aa326961'],
+};
+
+function random<T>(arr: T[]): T { return arr[Math.floor(Math.random() * arr.length)]; }
+function randomInt(min: number, max: number): number { return Math.floor(Math.random() * (max - min + 1)) + min; }
+
+function generateHost(index: number) {
+  const firstName = random(FIRST_NAMES);
+  const lastName = random(LAST_NAMES);
+  const location = random(CITIES);
+  const interests = random(INTEREST_SETS);
+  const photo = random(PHOTOS);
+  
+  const numExperiences = randomInt(1, 3);
+  const experiences = [];
+  const usedCategories = new Set<string>();
+  
+  for (let i = 0; i < numExperiences; i++) {
+    const category = random(CATEGORIES.filter(c => !usedCategories.has(c)));
+    usedCategories.add(category);
+    const templates = EXPERIENCE_TEMPLATES[category];
+    const template = random(templates);
+    const adj = random(ADJECTIVES);
+    const noun = random(NOUNS);
+    
+    experiences.push({
+      id: `exp-${index}-${i}`,
+      title: template.title.replace('{adj}', adj).replace('{noun}', noun),
+      description: template.desc,
+      category,
+      duration: random([90, 120, 150, 180, 240]),
+      price: randomInt(25, 150) * 100,
+      rating: (4.5 + Math.random() * 0.5).toFixed(1),
+      reviewCount: randomInt(5, 200),
+      photo: `https://images.unsplash.com/${random(EXP_PHOTOS[category])}?w=600&h=400&fit=crop`,
+    });
+  }
+
+  return {
+    id: `${firstName.toLowerCase()}-${location.city.toLowerCase().replace(/\s+/g, '-')}-${index}`,
+    name: `${firstName} ${lastName}`,
+    photo: `https://images.unsplash.com/${photo}?w=400&h=400&fit=crop&crop=face`,
+    city: location.city,
+    country: location.country,
+    bio: `Born and raised in ${location.city}. I love sharing my favorite spots with travelers who want to experience the real ${location.city}.`,
+    quote: `Let me show you the ${location.city} that only locals know.`,
+    interests,
+    languages: ['English', random(['Spanish', 'French', 'German', 'Japanese', 'Mandarin', 'Portuguese', 'Italian', 'Korean', 'Arabic', 'Hindi'])],
+    responseTime: random(['within an hour', 'within a few hours', 'within a day']),
+    memberSince: String(randomInt(2020, 2025)),
+    experiences,
+  };
+}
+
+// Generate 100 hosts
+const generatedHosts = Array.from({ length: 100 }, (_, i) => generateHost(i));
+console.log(JSON.stringify(generatedHosts, null, 2));

--- a/src/lib/data/generated-hosts.json
+++ b/src/lib/data/generated-hosts.json
@@ -1,0 +1,3207 @@
+[
+  {
+    "id": "yuki-lagos-0",
+    "name": "Yuki Park",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-0",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 12700,
+        "rating": 4.6,
+        "reviewCount": 12,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "chen-lagos-1",
+    "name": "Chen Ferrari",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-1",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 6900,
+        "rating": 4.6,
+        "reviewCount": 32,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "leo-accra-2",
+    "name": "Leo Patel",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Accra",
+    "country": "Ghana",
+    "bio": "Born in Accra. I love showing travelers the real city.",
+    "quote": "Let me show you Accra!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-2",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 4000,
+        "rating": 4.7,
+        "reviewCount": 33,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "benjamin-paris-3",
+    "name": "Benjamin Schmidt",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-3",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 12500,
+        "rating": 4.9,
+        "reviewCount": 19,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-stockholm-4",
+    "name": "Raj Ferrari",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Stockholm",
+    "country": "Sweden",
+    "bio": "Born in Stockholm. I love showing travelers the real city.",
+    "quote": "Let me show you Stockholm!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-4",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 11000,
+        "rating": 4.7,
+        "reviewCount": 113,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "leo-seoul-5",
+    "name": "Leo Ferrari",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Seoul",
+    "country": "South Korea",
+    "bio": "Born in Seoul. I love showing travelers the real city.",
+    "quote": "Let me show you Seoul!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-5",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 11300,
+        "rating": 4.8,
+        "reviewCount": 36,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ava-singapore-6",
+    "name": "Ava Ferrari",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Singapore",
+    "country": "Singapore",
+    "bio": "Born in Singapore. I love showing travelers the real city.",
+    "quote": "Let me show you Singapore!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-6",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 3400,
+        "rating": 4.9,
+        "reviewCount": 124,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aiden-sydney-7",
+    "name": "Aiden Mueller",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Sydney",
+    "country": "Australia",
+    "bio": "Born in Sydney. I love showing travelers the real city.",
+    "quote": "Let me show you Sydney!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-7",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 120,
+        "price": 7500,
+        "rating": 4.8,
+        "reviewCount": 60,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "jack-prague-8",
+    "name": "Jack Rossi",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Prague",
+    "country": "Czech Republic",
+    "bio": "Born in Prague. I love showing travelers the real city.",
+    "quote": "Let me show you Prague!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-8",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 3600,
+        "rating": 4.9,
+        "reviewCount": 105,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mei-sydney-9",
+    "name": "Mei Rossi",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Sydney",
+    "country": "Australia",
+    "bio": "Born in Sydney. I love showing travelers the real city.",
+    "quote": "Let me show you Sydney!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-9",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 90,
+        "price": 12700,
+        "rating": 4.6,
+        "reviewCount": 14,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "sofia-lagos-10",
+    "name": "Sofia Rossi",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-10",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 120,
+        "price": 10600,
+        "rating": 4.7,
+        "reviewCount": 14,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mia-rome-11",
+    "name": "Mia Lee",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Rome",
+    "country": "Italy",
+    "bio": "Born in Rome. I love showing travelers the real city.",
+    "quote": "Let me show you Rome!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-11",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 5300,
+        "rating": 4.8,
+        "reviewCount": 61,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "fatima-accra-12",
+    "name": "Fatima Weber",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Accra",
+    "country": "Ghana",
+    "bio": "Born in Accra. I love showing travelers the real city.",
+    "quote": "Let me show you Accra!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-12",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 3300,
+        "rating": 4.7,
+        "reviewCount": 63,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mia-istanbul-13",
+    "name": "Mia Wang",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Istanbul",
+    "country": "Turkey",
+    "bio": "Born in Istanbul. I love showing travelers the real city.",
+    "quote": "Let me show you Istanbul!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-13",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 4900,
+        "rating": 4.9,
+        "reviewCount": 84,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "luna-stockholm-14",
+    "name": "Luna Rossi",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Stockholm",
+    "country": "Sweden",
+    "bio": "Born in Stockholm. I love showing travelers the real city.",
+    "quote": "Let me show you Stockholm!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-14",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 6400,
+        "rating": 5,
+        "reviewCount": 132,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "benjamin-rio-de-janeiro-15",
+    "name": "Benjamin Chen",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Rio de Janeiro",
+    "country": "Brazil",
+    "bio": "Born in Rio de Janeiro. I love showing travelers the real city.",
+    "quote": "Let me show you Rio de Janeiro!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-15",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 9000,
+        "rating": 4.7,
+        "reviewCount": 90,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "emma-dubai-16",
+    "name": "Emma Santos",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Dubai",
+    "country": "UAE",
+    "bio": "Born in Dubai. I love showing travelers the real city.",
+    "quote": "Let me show you Dubai!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-16",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 120,
+        "price": 11600,
+        "rating": 4.7,
+        "reviewCount": 13,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aria-london-17",
+    "name": "Aria Wang",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "London",
+    "country": "UK",
+    "bio": "Born in London. I love showing travelers the real city.",
+    "quote": "Let me show you London!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-17",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 11200,
+        "rating": 4.8,
+        "reviewCount": 7,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "emma-buenos-aires-18",
+    "name": "Emma Patel",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Buenos Aires",
+    "country": "Argentina",
+    "bio": "Born in Buenos Aires. I love showing travelers the real city.",
+    "quote": "Let me show you Buenos Aires!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-18",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 90,
+        "price": 9600,
+        "rating": 4.9,
+        "reviewCount": 59,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mohammed-paris-19",
+    "name": "Mohammed Schmidt",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-19",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 3600,
+        "rating": 4.6,
+        "reviewCount": 123,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "kofi-bangkok-20",
+    "name": "Kofi Wang",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Bangkok",
+    "country": "Thailand",
+    "bio": "Born in Bangkok. I love showing travelers the real city.",
+    "quote": "Let me show you Bangkok!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-20",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 180,
+        "price": 4600,
+        "rating": 4.7,
+        "reviewCount": 100,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "olivia-amsterdam-21",
+    "name": "Olivia Garcia",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "bio": "Born in Amsterdam. I love showing travelers the real city.",
+    "quote": "Let me show you Amsterdam!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-21",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 8900,
+        "rating": 4.9,
+        "reviewCount": 126,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "omar-sydney-22",
+    "name": "Omar Kim",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Sydney",
+    "country": "Australia",
+    "bio": "Born in Sydney. I love showing travelers the real city.",
+    "quote": "Let me show you Sydney!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-22",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 7600,
+        "rating": 4.6,
+        "reviewCount": 49,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mason-singapore-23",
+    "name": "Mason Wang",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Singapore",
+    "country": "Singapore",
+    "bio": "Born in Singapore. I love showing travelers the real city.",
+    "quote": "Let me show you Singapore!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-23",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 10600,
+        "rating": 4.7,
+        "reviewCount": 150,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "kofi-mumbai-24",
+    "name": "Kofi Patel",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-24",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 9000,
+        "rating": 4.6,
+        "reviewCount": 18,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "emma-lisbon-25",
+    "name": "Emma Smith",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "cooking",
+      "wine",
+      "food"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-25",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 10500,
+        "rating": 4.9,
+        "reviewCount": 60,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-paris-26",
+    "name": "Liam Schmidt",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-26",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 3800,
+        "rating": 4.8,
+        "reviewCount": 62,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "isabella-nairobi-27",
+    "name": "Isabella Patel",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Nairobi",
+    "country": "Kenya",
+    "bio": "Born in Nairobi. I love showing travelers the real city.",
+    "quote": "Let me show you Nairobi!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-27",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 11700,
+        "rating": 4.6,
+        "reviewCount": 28,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "leo-mumbai-28",
+    "name": "Leo Ali",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-28",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 10500,
+        "rating": 4.9,
+        "reviewCount": 21,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-buenos-aires-29",
+    "name": "Raj Santos",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Buenos Aires",
+    "country": "Argentina",
+    "bio": "Born in Buenos Aires. I love showing travelers the real city.",
+    "quote": "Let me show you Buenos Aires!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-29",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 10000,
+        "rating": 4.8,
+        "reviewCount": 135,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "jack-prague-30",
+    "name": "Jack Tanaka",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Prague",
+    "country": "Czech Republic",
+    "bio": "Born in Prague. I love showing travelers the real city.",
+    "quote": "Let me show you Prague!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-30",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 4900,
+        "rating": 5,
+        "reviewCount": 139,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "yuki-berlin-31",
+    "name": "Yuki Silva",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Berlin",
+    "country": "Germany",
+    "bio": "Born in Berlin. I love showing travelers the real city.",
+    "quote": "Let me show you Berlin!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-31",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 7100,
+        "rating": 4.9,
+        "reviewCount": 98,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aiden-london-32",
+    "name": "Aiden Wang",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "London",
+    "country": "UK",
+    "bio": "Born in London. I love showing travelers the real city.",
+    "quote": "Let me show you London!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-32",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 4600,
+        "rating": 4.8,
+        "reviewCount": 130,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-mumbai-33",
+    "name": "Liam Nguyen",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-33",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 90,
+        "price": 11300,
+        "rating": 4.6,
+        "reviewCount": 106,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "james-rio-de-janeiro-34",
+    "name": "James Schmidt",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Rio de Janeiro",
+    "country": "Brazil",
+    "bio": "Born in Rio de Janeiro. I love showing travelers the real city.",
+    "quote": "Let me show you Rio de Janeiro!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-34",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 7800,
+        "rating": 4.7,
+        "reviewCount": 65,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "lucas-vienna-35",
+    "name": "Lucas Park",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Vienna",
+    "country": "Austria",
+    "bio": "Born in Vienna. I love showing travelers the real city.",
+    "quote": "Let me show you Vienna!",
+    "interests": [
+      "cooking",
+      "wine",
+      "food"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-35",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 8100,
+        "rating": 4.9,
+        "reviewCount": 42,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-bangkok-36",
+    "name": "Liam Wang",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Bangkok",
+    "country": "Thailand",
+    "bio": "Born in Bangkok. I love showing travelers the real city.",
+    "quote": "Let me show you Bangkok!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-36",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 8900,
+        "rating": 4.8,
+        "reviewCount": 48,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mohammed-lisbon-37",
+    "name": "Mohammed Nguyen",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-37",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 120,
+        "price": 8500,
+        "rating": 4.9,
+        "reviewCount": 52,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "amara-berlin-38",
+    "name": "Amara Wang",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Berlin",
+    "country": "Germany",
+    "bio": "Born in Berlin. I love showing travelers the real city.",
+    "quote": "Let me show you Berlin!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-38",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 8300,
+        "rating": 4.8,
+        "reviewCount": 38,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-vienna-39",
+    "name": "Liam Weber",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Vienna",
+    "country": "Austria",
+    "bio": "Born in Vienna. I love showing travelers the real city.",
+    "quote": "Let me show you Vienna!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-39",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 8800,
+        "rating": 4.7,
+        "reviewCount": 111,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mia-lagos-40",
+    "name": "Mia Ali",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-40",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 6600,
+        "rating": 4.9,
+        "reviewCount": 103,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "chen-berlin-41",
+    "name": "Chen Mueller",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Berlin",
+    "country": "Germany",
+    "bio": "Born in Berlin. I love showing travelers the real city.",
+    "quote": "Let me show you Berlin!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-41",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 5700,
+        "rating": 4.7,
+        "reviewCount": 49,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "olivia-marrakech-42",
+    "name": "Olivia Lee",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Marrakech",
+    "country": "Morocco",
+    "bio": "Born in Marrakech. I love showing travelers the real city.",
+    "quote": "Let me show you Marrakech!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-42",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 6600,
+        "rating": 4.8,
+        "reviewCount": 26,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-lagos-43",
+    "name": "Raj Mueller",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-43",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 5000,
+        "rating": 4.7,
+        "reviewCount": 154,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "yuki-seoul-44",
+    "name": "Yuki Mueller",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Seoul",
+    "country": "South Korea",
+    "bio": "Born in Seoul. I love showing travelers the real city.",
+    "quote": "Let me show you Seoul!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-44",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 180,
+        "price": 4200,
+        "rating": 4.7,
+        "reviewCount": 151,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "fatima-prague-45",
+    "name": "Fatima Tanaka",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Prague",
+    "country": "Czech Republic",
+    "bio": "Born in Prague. I love showing travelers the real city.",
+    "quote": "Let me show you Prague!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-45",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 4400,
+        "rating": 4.7,
+        "reviewCount": 42,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ethan-kyoto-46",
+    "name": "Ethan Kim",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Kyoto",
+    "country": "Japan",
+    "bio": "Born in Kyoto. I love showing travelers the real city.",
+    "quote": "Let me show you Kyoto!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-46",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 7400,
+        "rating": 4.5,
+        "reviewCount": 34,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "olivia-paris-47",
+    "name": "Olivia Smith",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-47",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 3500,
+        "rating": 4.8,
+        "reviewCount": 25,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mia-berlin-48",
+    "name": "Mia Smith",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Berlin",
+    "country": "Germany",
+    "bio": "Born in Berlin. I love showing travelers the real city.",
+    "quote": "Let me show you Berlin!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-48",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 6700,
+        "rating": 4.8,
+        "reviewCount": 144,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-stockholm-49",
+    "name": "Raj Garcia",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Stockholm",
+    "country": "Sweden",
+    "bio": "Born in Stockholm. I love showing travelers the real city.",
+    "quote": "Let me show you Stockholm!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-49",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 120,
+        "price": 9200,
+        "rating": 4.8,
+        "reviewCount": 102,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mason-athens-50",
+    "name": "Mason Tanaka",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Athens",
+    "country": "Greece",
+    "bio": "Born in Athens. I love showing travelers the real city.",
+    "quote": "Let me show you Athens!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-50",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 4500,
+        "rating": 4.6,
+        "reviewCount": 50,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "amara-vienna-51",
+    "name": "Amara Weber",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Vienna",
+    "country": "Austria",
+    "bio": "Born in Vienna. I love showing travelers the real city.",
+    "quote": "Let me show you Vienna!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-51",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 7400,
+        "rating": 4.6,
+        "reviewCount": 95,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-singapore-52",
+    "name": "Liam Ali",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Singapore",
+    "country": "Singapore",
+    "bio": "Born in Singapore. I love showing travelers the real city.",
+    "quote": "Let me show you Singapore!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-52",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 120,
+        "price": 9200,
+        "rating": 4.6,
+        "reviewCount": 10,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-paris-53",
+    "name": "Raj Smith",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-53",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 180,
+        "price": 4600,
+        "rating": 4.7,
+        "reviewCount": 95,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "yuki-lisbon-54",
+    "name": "Yuki Santos",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-54",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 9000,
+        "rating": 4.9,
+        "reviewCount": 36,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "emma-berlin-55",
+    "name": "Emma Lee",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Berlin",
+    "country": "Germany",
+    "bio": "Born in Berlin. I love showing travelers the real city.",
+    "quote": "Let me show you Berlin!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-55",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 12800,
+        "rating": 4.9,
+        "reviewCount": 48,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "sofia-seoul-56",
+    "name": "Sofia Garcia",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Seoul",
+    "country": "South Korea",
+    "bio": "Born in Seoul. I love showing travelers the real city.",
+    "quote": "Let me show you Seoul!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-56",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 180,
+        "price": 5500,
+        "rating": 4.9,
+        "reviewCount": 56,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-nairobi-57",
+    "name": "Liam Rossi",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Nairobi",
+    "country": "Kenya",
+    "bio": "Born in Nairobi. I love showing travelers the real city.",
+    "quote": "Let me show you Nairobi!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-57",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 12300,
+        "rating": 5,
+        "reviewCount": 34,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aiden-barcelona-58",
+    "name": "Aiden Tanaka",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Barcelona",
+    "country": "Spain",
+    "bio": "Born in Barcelona. I love showing travelers the real city.",
+    "quote": "Let me show you Barcelona!",
+    "interests": [
+      "cooking",
+      "wine",
+      "food"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-58",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 120,
+        "price": 11600,
+        "rating": 4.8,
+        "reviewCount": 129,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ava-seoul-59",
+    "name": "Ava Tanaka",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Seoul",
+    "country": "South Korea",
+    "bio": "Born in Seoul. I love showing travelers the real city.",
+    "quote": "Let me show you Seoul!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-59",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 180,
+        "price": 8700,
+        "rating": 4.8,
+        "reviewCount": 105,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ethan-paris-60",
+    "name": "Ethan Smith",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-60",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 11200,
+        "rating": 4.9,
+        "reviewCount": 137,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "lucas-london-61",
+    "name": "Lucas Garcia",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "London",
+    "country": "UK",
+    "bio": "Born in London. I love showing travelers the real city.",
+    "quote": "Let me show you London!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-61",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 10200,
+        "rating": 4.8,
+        "reviewCount": 51,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "james-copenhagen-62",
+    "name": "James Hassan",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Copenhagen",
+    "country": "Denmark",
+    "bio": "Born in Copenhagen. I love showing travelers the real city.",
+    "quote": "Let me show you Copenhagen!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-62",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 3900,
+        "rating": 4.5,
+        "reviewCount": 102,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "fatima-mumbai-63",
+    "name": "Fatima Smith",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-63",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 90,
+        "price": 12100,
+        "rating": 5,
+        "reviewCount": 138,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mohammed-cape-town-64",
+    "name": "Mohammed Lee",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Cape Town",
+    "country": "South Africa",
+    "bio": "Born in Cape Town. I love showing travelers the real city.",
+    "quote": "Let me show you Cape Town!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-64",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 4400,
+        "rating": 4.7,
+        "reviewCount": 141,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "jack-lagos-65",
+    "name": "Jack Kim",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Lagos",
+    "country": "Nigeria",
+    "bio": "Born in Lagos. I love showing travelers the real city.",
+    "quote": "Let me show you Lagos!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-65",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 180,
+        "price": 10500,
+        "rating": 4.7,
+        "reviewCount": 5,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "isabella-istanbul-66",
+    "name": "Isabella Park",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Istanbul",
+    "country": "Turkey",
+    "bio": "Born in Istanbul. I love showing travelers the real city.",
+    "quote": "Let me show you Istanbul!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-66",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 6800,
+        "rating": 4.9,
+        "reviewCount": 9,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "chloe-prague-67",
+    "name": "Chloe Yamamoto",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Prague",
+    "country": "Czech Republic",
+    "bio": "Born in Prague. I love showing travelers the real city.",
+    "quote": "Let me show you Prague!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-67",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 120,
+        "price": 9900,
+        "rating": 4.7,
+        "reviewCount": 5,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "emma-athens-68",
+    "name": "Emma Silva",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Athens",
+    "country": "Greece",
+    "bio": "Born in Athens. I love showing travelers the real city.",
+    "quote": "Let me show you Athens!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-68",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 180,
+        "price": 3400,
+        "rating": 4.7,
+        "reviewCount": 84,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "olivia-new-york-69",
+    "name": "Olivia Santos",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "New York",
+    "country": "USA",
+    "bio": "Born in New York. I love showing travelers the real city.",
+    "quote": "Let me show you New York!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-69",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 90,
+        "price": 11800,
+        "rating": 4.9,
+        "reviewCount": 30,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "omar-tokyo-70",
+    "name": "Omar Smith",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Tokyo",
+    "country": "Japan",
+    "bio": "Born in Tokyo. I love showing travelers the real city.",
+    "quote": "Let me show you Tokyo!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-70",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 4400,
+        "rating": 4.7,
+        "reviewCount": 103,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aria-accra-71",
+    "name": "Aria Yamamoto",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Accra",
+    "country": "Ghana",
+    "bio": "Born in Accra. I love showing travelers the real city.",
+    "quote": "Let me show you Accra!",
+    "interests": [
+      "street food",
+      "markets"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-71",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 4400,
+        "rating": 4.7,
+        "reviewCount": 139,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "priya-tokyo-72",
+    "name": "Priya Mueller",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Tokyo",
+    "country": "Japan",
+    "bio": "Born in Tokyo. I love showing travelers the real city.",
+    "quote": "Let me show you Tokyo!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-72",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 6400,
+        "rating": 4.7,
+        "reviewCount": 17,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-athens-73",
+    "name": "Raj Kim",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Athens",
+    "country": "Greece",
+    "bio": "Born in Athens. I love showing travelers the real city.",
+    "quote": "Let me show you Athens!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-73",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 120,
+        "price": 11000,
+        "rating": 4.5,
+        "reviewCount": 52,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "chen-mumbai-74",
+    "name": "Chen Chen",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-74",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 5700,
+        "rating": 4.9,
+        "reviewCount": 120,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "amara-vienna-75",
+    "name": "Amara Smith",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Vienna",
+    "country": "Austria",
+    "bio": "Born in Vienna. I love showing travelers the real city.",
+    "quote": "Let me show you Vienna!",
+    "interests": [
+      "cooking",
+      "wine",
+      "food"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-75",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 90,
+        "price": 7300,
+        "rating": 4.9,
+        "reviewCount": 11,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "sofia-kyoto-76",
+    "name": "Sofia Kim",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Kyoto",
+    "country": "Japan",
+    "bio": "Born in Kyoto. I love showing travelers the real city.",
+    "quote": "Let me show you Kyoto!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-76",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 120,
+        "price": 3200,
+        "rating": 4.8,
+        "reviewCount": 15,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "isabella-buenos-aires-77",
+    "name": "Isabella Nguyen",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Buenos Aires",
+    "country": "Argentina",
+    "bio": "Born in Buenos Aires. I love showing travelers the real city.",
+    "quote": "Let me show you Buenos Aires!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-77",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 7000,
+        "rating": 4.8,
+        "reviewCount": 101,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "leo-marrakech-78",
+    "name": "Leo Santos",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Marrakech",
+    "country": "Morocco",
+    "bio": "Born in Marrakech. I love showing travelers the real city.",
+    "quote": "Let me show you Marrakech!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-78",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "wellness",
+        "duration": 90,
+        "price": 12400,
+        "rating": 4.8,
+        "reviewCount": 18,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "yuki-singapore-79",
+    "name": "Yuki Mueller",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Singapore",
+    "country": "Singapore",
+    "bio": "Born in Singapore. I love showing travelers the real city.",
+    "quote": "Let me show you Singapore!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-79",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 120,
+        "price": 9400,
+        "rating": 4.6,
+        "reviewCount": 23,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "luna-stockholm-80",
+    "name": "Luna Smith",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Stockholm",
+    "country": "Sweden",
+    "bio": "Born in Stockholm. I love showing travelers the real city.",
+    "quote": "Let me show you Stockholm!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-80",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 9300,
+        "rating": 4.6,
+        "reviewCount": 121,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-istanbul-81",
+    "name": "Raj Rossi",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Istanbul",
+    "country": "Turkey",
+    "bio": "Born in Istanbul. I love showing travelers the real city.",
+    "quote": "Let me show you Istanbul!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-81",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 90,
+        "price": 3300,
+        "rating": 4.9,
+        "reviewCount": 138,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "benjamin-lisbon-82",
+    "name": "Benjamin Tanaka",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-82",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 120,
+        "price": 3500,
+        "rating": 4.6,
+        "reviewCount": 74,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "aria-mumbai-83",
+    "name": "Aria Wang",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Mumbai",
+    "country": "India",
+    "bio": "Born in Mumbai. I love showing travelers the real city.",
+    "quote": "Let me show you Mumbai!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-83",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 9200,
+        "rating": 4.5,
+        "reviewCount": 36,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "fatima-istanbul-84",
+    "name": "Fatima Tanaka",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Istanbul",
+    "country": "Turkey",
+    "bio": "Born in Istanbul. I love showing travelers the real city.",
+    "quote": "Let me show you Istanbul!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-84",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 90,
+        "price": 10600,
+        "rating": 4.7,
+        "reviewCount": 138,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mason-lisbon-85",
+    "name": "Mason Kim",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-85",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 7900,
+        "rating": 4.6,
+        "reviewCount": 135,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "raj-kyoto-86",
+    "name": "Raj Schmidt",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Kyoto",
+    "country": "Japan",
+    "bio": "Born in Kyoto. I love showing travelers the real city.",
+    "quote": "Let me show you Kyoto!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-86",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 180,
+        "price": 11000,
+        "rating": 5,
+        "reviewCount": 67,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "fatima-seoul-87",
+    "name": "Fatima Ferrari",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Seoul",
+    "country": "South Korea",
+    "bio": "Born in Seoul. I love showing travelers the real city.",
+    "quote": "Let me show you Seoul!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-87",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "learning",
+        "duration": 90,
+        "price": 6100,
+        "rating": 4.8,
+        "reviewCount": 151,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "liam-paris-88",
+    "name": "Liam Rossi",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Spanish"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-88",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 120,
+        "price": 8400,
+        "rating": 5,
+        "reviewCount": 54,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "priya-rio-de-janeiro-89",
+    "name": "Priya Schmidt",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Rio de Janeiro",
+    "country": "Brazil",
+    "bio": "Born in Rio de Janeiro. I love showing travelers the real city.",
+    "quote": "Let me show you Rio de Janeiro!",
+    "interests": [
+      "meditation",
+      "yoga"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-89",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "outdoor-adventure",
+        "duration": 180,
+        "price": 8800,
+        "rating": 4.9,
+        "reviewCount": 123,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "sofia-cape-town-90",
+    "name": "Sofia Rossi",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Cape Town",
+    "country": "South Africa",
+    "bio": "Born in Cape Town. I love showing travelers the real city.",
+    "quote": "Let me show you Cape Town!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-90",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 8500,
+        "rating": 4.7,
+        "reviewCount": 8,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "chloe-barcelona-91",
+    "name": "Chloe Garcia",
+    "photo": "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face",
+    "city": "Barcelona",
+    "country": "Spain",
+    "bio": "Born in Barcelona. I love showing travelers the real city.",
+    "quote": "Let me show you Barcelona!",
+    "interests": [
+      "history",
+      "architecture"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2023",
+    "experiences": [
+      {
+        "id": "exp-91",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 120,
+        "price": 11100,
+        "rating": 4.8,
+        "reviewCount": 78,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "mei-marrakech-92",
+    "name": "Mei Rossi",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Marrakech",
+    "country": "Morocco",
+    "bio": "Born in Marrakech. I love showing travelers the real city.",
+    "quote": "Let me show you Marrakech!",
+    "interests": [
+      "craft beer",
+      "breweries"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-92",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 180,
+        "price": 10100,
+        "rating": 4.7,
+        "reviewCount": 49,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ethan-lisbon-93",
+    "name": "Ethan Ferrari",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "bio": "Born in Lisbon. I love showing travelers the real city.",
+    "quote": "Let me show you Lisbon!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2022",
+    "experiences": [
+      {
+        "id": "exp-93",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 8300,
+        "rating": 4.5,
+        "reviewCount": 7,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "luna-singapore-94",
+    "name": "Luna Hassan",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Singapore",
+    "country": "Singapore",
+    "bio": "Born in Singapore. I love showing travelers the real city.",
+    "quote": "Let me show you Singapore!",
+    "interests": [
+      "surfing",
+      "beach"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2024",
+    "experiences": [
+      {
+        "id": "exp-94",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 120,
+        "price": 10800,
+        "rating": 4.7,
+        "reviewCount": 73,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "benjamin-kyoto-95",
+    "name": "Benjamin Mueller",
+    "photo": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face",
+    "city": "Kyoto",
+    "country": "Japan",
+    "bio": "Born in Kyoto. I love showing travelers the real city.",
+    "quote": "Let me show you Kyoto!",
+    "interests": [
+      "cooking",
+      "wine",
+      "food"
+    ],
+    "languages": [
+      "English",
+      "German"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-95",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 180,
+        "price": 10600,
+        "rating": 4.9,
+        "reviewCount": 139,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "olivia-rio-de-janeiro-96",
+    "name": "Olivia Rossi",
+    "photo": "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face",
+    "city": "Rio de Janeiro",
+    "country": "Brazil",
+    "bio": "Born in Rio de Janeiro. I love showing travelers the real city.",
+    "quote": "Let me show you Rio de Janeiro!",
+    "interests": [
+      "hiking",
+      "nature"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-96",
+        "title": "Secret Food Tour",
+        "description": "An authentic local experience.",
+        "category": "nightlife-social",
+        "duration": 90,
+        "price": 12900,
+        "rating": 4.5,
+        "reviewCount": 123,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "leo-copenhagen-97",
+    "name": "Leo Garcia",
+    "photo": "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face",
+    "city": "Copenhagen",
+    "country": "Denmark",
+    "bio": "Born in Copenhagen. I love showing travelers the real city.",
+    "quote": "Let me show you Copenhagen!",
+    "interests": [
+      "street art",
+      "photography"
+    ],
+    "languages": [
+      "English",
+      "Japanese"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2021",
+    "experiences": [
+      {
+        "id": "exp-97",
+        "title": "Hidden Gems Walk",
+        "description": "An authentic local experience.",
+        "category": "arts-culture",
+        "duration": 120,
+        "price": 3600,
+        "rating": 4.5,
+        "reviewCount": 111,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "ethan-paris-98",
+    "name": "Ethan Ferrari",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Paris",
+    "country": "France",
+    "bio": "Born in Paris. I love showing travelers the real city.",
+    "quote": "Let me show you Paris!",
+    "interests": [
+      "coffee",
+      "cafes"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-98",
+        "title": "Local Experience",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 180,
+        "price": 5300,
+        "rating": 4.5,
+        "reviewCount": 24,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  },
+  {
+    "id": "benjamin-bangkok-99",
+    "name": "Benjamin Tanaka",
+    "photo": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face",
+    "city": "Bangkok",
+    "country": "Thailand",
+    "bio": "Born in Bangkok. I love showing travelers the real city.",
+    "quote": "Let me show you Bangkok!",
+    "interests": [
+      "nightlife",
+      "music"
+    ],
+    "languages": [
+      "English",
+      "French"
+    ],
+    "responseTime": "within a few hours",
+    "memberSince": "2020",
+    "experiences": [
+      {
+        "id": "exp-99",
+        "title": "Sunset Adventure",
+        "description": "An authentic local experience.",
+        "category": "food-drink",
+        "duration": 90,
+        "price": 7300,
+        "rating": 4.8,
+        "reviewCount": 86,
+        "photo": "https://images.unsplash.com/photo-1556910103-1c02745aae4d?w=600&h=400&fit=crop"
+      }
+    ]
+  }
+]

--- a/src/lib/data/hosts.ts
+++ b/src/lib/data/hosts.ts
@@ -28,7 +28,7 @@ export interface HostExperience {
 }
 
 // Rich host profiles - these are the core entity now
-export const HOSTS: Host[] = [
+const CURATED_HOSTS: Host[] = [
   {
     id: 'maria-rome',
     name: 'Maria Rossi',
@@ -230,6 +230,10 @@ export const HOSTS: Host[] = [
     ],
   },
 ];
+
+// Import generated hosts and merge with curated ones
+import generatedHosts from './generated-hosts.json';
+export const HOSTS: Host[] = [...CURATED_HOSTS, ...(generatedHosts as Host[])];
 
 // Helper function to get a host by ID
 export function getHostById(id: string): Host | undefined {

--- a/src/types/globe.ts
+++ b/src/types/globe.ts
@@ -1,0 +1,105 @@
+// Globe itinerary types for Resium/CesiumJS visualization
+
+export interface GlobeDestination {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  day: number;
+  activities: string[];
+  color: string;
+}
+
+export interface TravelRoute {
+  id: string;
+  fromId: string;
+  toId: string;
+  fromLat: number;
+  fromLng: number;
+  toLat: number;
+  toLng: number;
+  mode: 'flight' | 'train' | 'drive' | 'walk';
+}
+
+export interface GlobeItinerary {
+  id: string;
+  title: string;
+  destinations: GlobeDestination[];
+  routes: TravelRoute[];
+  createdAt: string;
+}
+
+// Helper to generate unique IDs
+export function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// Color palette for destinations by day
+export const DAY_COLORS = [
+  '#fb8500', // Day 1 - Princeton Orange
+  '#219ebc', // Day 2 - Blue Green
+  '#8ecae6', // Day 3 - Sky Blue
+  '#ffb703', // Day 4 - Amber
+  '#023047', // Day 5 - Deep Space Blue
+  '#e63946', // Day 6 - Red
+  '#2a9d8f', // Day 7 - Teal
+  '#9b5de5', // Day 8 - Purple
+];
+
+export function getColorForDay(day: number): string {
+  return DAY_COLORS[(day - 1) % DAY_COLORS.length];
+}
+
+// Sample destinations for testing
+export const SAMPLE_DESTINATIONS: GlobeDestination[] = [
+  {
+    id: 'tokyo',
+    name: 'Tokyo',
+    lat: 35.6762,
+    lng: 139.6503,
+    day: 1,
+    activities: ['Arrive at Narita', 'Check in to hotel', 'Explore Shibuya'],
+    color: DAY_COLORS[0],
+  },
+  {
+    id: 'kyoto',
+    name: 'Kyoto',
+    lat: 35.0116,
+    lng: 135.7681,
+    day: 3,
+    activities: ['Fushimi Inari', 'Kinkaku-ji Temple', 'Gion district'],
+    color: DAY_COLORS[2],
+  },
+  {
+    id: 'osaka',
+    name: 'Osaka',
+    lat: 34.6937,
+    lng: 135.5023,
+    day: 5,
+    activities: ['Dotonbori', 'Osaka Castle', 'Street food tour'],
+    color: DAY_COLORS[4],
+  },
+];
+
+export const SAMPLE_ROUTES: TravelRoute[] = [
+  {
+    id: 'tokyo-kyoto',
+    fromId: 'tokyo',
+    toId: 'kyoto',
+    fromLat: 35.6762,
+    fromLng: 139.6503,
+    toLat: 35.0116,
+    toLng: 135.7681,
+    mode: 'train',
+  },
+  {
+    id: 'kyoto-osaka',
+    fromId: 'kyoto',
+    toId: 'osaka',
+    fromLat: 35.0116,
+    fromLng: 135.7681,
+    toLat: 34.6937,
+    toLng: 135.5023,
+    mode: 'train',
+  },
+];

--- a/src/types/itinerary.ts
+++ b/src/types/itinerary.ts
@@ -1,0 +1,110 @@
+// Itinerary types for the visual builder
+
+export type ItineraryItemType = 
+  | 'activity' 
+  | 'meal' 
+  | 'transport' 
+  | 'accommodation' 
+  | 'localhost';
+
+export const ITEM_TYPE_CONFIG: Record<ItineraryItemType, { label: string; icon: string; color: string }> = {
+  activity: { label: 'Activity', icon: '🎯', color: 'var(--blue-green)' },
+  meal: { label: 'Food & Drink', icon: '🍽️', color: 'var(--princeton-orange)' },
+  transport: { label: 'Transport', icon: '🚗', color: 'var(--muted)' },
+  accommodation: { label: 'Accommodation', icon: '🏨', color: 'var(--deep-space-blue)' },
+  localhost: { label: 'Localhost', icon: '👤', color: 'var(--amber-flame)' },
+};
+
+export interface ItineraryItem {
+  id: string;
+  type: ItineraryItemType;
+  title: string;
+  description?: string;
+  location?: string;
+  startTime?: string; // HH:MM format
+  endTime?: string;
+  hostId?: string; // Future: link to Localhost experience
+  position: number;
+}
+
+export interface ItineraryDay {
+  id: string;
+  date: string; // ISO date string (YYYY-MM-DD)
+  dayNumber: number;
+  items: ItineraryItem[];
+}
+
+export interface Itinerary {
+  id: string;
+  title: string;
+  destination: string;
+  startDate: string; // ISO date string
+  endDate: string;
+  days: ItineraryDay[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Helper to generate unique IDs
+export function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// Helper to create days array from date range
+export function createDaysFromRange(startDate: string, endDate: string): ItineraryDay[] {
+  const days: ItineraryDay[] = [];
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  
+  let dayNumber = 1;
+  const current = new Date(start);
+  
+  while (current <= end) {
+    days.push({
+      id: generateId(),
+      date: current.toISOString().split('T')[0],
+      dayNumber,
+      items: [],
+    });
+    current.setDate(current.getDate() + 1);
+    dayNumber++;
+  }
+  
+  return days;
+}
+
+// Helper to create a new itinerary
+export function createItinerary(
+  title: string, 
+  destination: string, 
+  startDate: string, 
+  endDate: string
+): Itinerary {
+  const now = new Date().toISOString();
+  return {
+    id: generateId(),
+    title,
+    destination,
+    startDate,
+    endDate,
+    days: createDaysFromRange(startDate, endDate),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// Helper to create a new item
+export function createItem(
+  type: ItineraryItemType,
+  title: string,
+  position: number,
+  options?: Partial<Omit<ItineraryItem, 'id' | 'type' | 'title' | 'position'>>
+): ItineraryItem {
+  return {
+    id: generateId(),
+    type,
+    title,
+    position,
+    ...options,
+  };
+}


### PR DESCRIPTION
- Add interactive 3D globe with OpenStreetMap tiles
- Add AI chat panel for conversational trip planning
- Add timeline navigation with camera fly-to animations
- Add destination markers and route visualization
- Integrate with existing chat API for itinerary generation

Features:
- Real-time globe visualization using Resium/CesiumJS
- Demo mode with Tokyo → Kyoto → Osaka itinerary
- Click timeline items to fly camera to destinations
- AI can generate destinations with lat/lng coordinates

New files:
- src/app/itinerary/page.tsx - Main itinerary page
- src/components/features/cesium-globe.tsx - Cesium globe component
- src/components/features/globe-itinerary.tsx - Layout with globe + chat
- src/types/globe.ts - Globe destination/route types

Configuration:
- Updated next.config.ts for Cesium webpack/turbopack
- Added postinstall script for Cesium assets symlink
- Using OpenStreetMap tiles (no API key required)